### PR TITLE
Shared library build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,18 @@ macro(opencollada_add_lib
 		endif ()
 		add_library(${name}_shared SHARED ${sources})
 		set_target_properties(${name}_shared PROPERTIES OUTPUT_NAME ${name})
-		target_link_libraries(${name}_shared ${target_libs})
+
+		set(target_libs_TMP)
+		foreach(l ${target_libs})
+			if (NOT EXISTS ${l})
+				list(APPEND target_libs_TMP ${l}_shared )
+			else ()
+				list(APPEND target_libs_TMP ${l} )
+			endif ()
+		endforeach()
+		target_link_libraries(${name}_shared ${target_libs_TMP})
+		unset(target_libs_TMP)
+
 		set(CMAKE_REQUIRED_LIBRARIES "${name}_shared;${CMAKE_REQUIRED_LIBRARIES}"  PARENT_SCOPE)
 
 		install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ endif ()
 # Install vars
 
 set(OPENCOLLADA_INST_INCLUDE ${CMAKE_INSTALL_PREFIX}/include/opencollada)
-set(OPENCOLLADA_INST_LIBRARY ${CMAKE_INSTALL_PREFIX}/lib/opencollada)
+set(OPENCOLLADA_INST_LIBRARY ${CMAKE_INSTALL_PREFIX}/lib)
 
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ endif ()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${C_WARNINGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_WARNINGS}")
 
+if (USE_SHARED)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+endif ()
+
 
 #-----------------------------------------------------------------------------
 # Install vars


### PR DESCRIPTION
Building shared librariries failed for two reasons for me.

1. Build was trying to use position depend objects for shared library that failed during linking.

Fix is simple adition of -fPIC to the compiler lines.

2. CMake wasn't adding dependencies between shared libraries that required linking

The fix simple adds the _shared prefix to the library name when depending to an internal library. That allows cmake to track dependencies correctly allowing parallel builds to success.