### PR TITLE
Added LIBXML_STATIC define for proper build of LibXML

### DIFF
--- a/Externals/LibXML/CMakeLists.txt
+++ b/Externals/LibXML/CMakeLists.txt
@@ -5,6 +5,8 @@ set(libxml_include_dirs
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+add_definitions( -DLIBXML_STATIC )
+
 set(libxml_include_dirs ${libxml_include_dirs} PARENT_SCOPE)  # adding include dirs to a parent scope
 
 set(SRC


### PR DESCRIPTION
when using the included Externals/LibXML int the build, the define is necessary to avoid the lib to define DLLMain() that then conflict if the library is used to create a dll
