### PR TITLE
Add Library Prefix option for Debug libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/Externals/cmake-modules")
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Only do Release and Debug" FORCE )
 mark_as_advanced(CMAKE_CONFIGURATION_TYPES)
 
+SET(CMAKE_DEBUG_POSTFIX ""  CACHE STRING "Add this string to as suffix to Debug libraries, e.g.: xml2_d.lib " )
 
 #-----------------------------------------------------------------------------
 # Macro's


### PR DESCRIPTION
This change simply adds a configurable suffix to debug libraries. This allows to build debug libraries and release libraries with unique names. The default is set to not use a suffix, so this change should have minimal impact on the project.

Motivation: A configurable suffix allows me to install the Debug libraries and the Release libraries to the same location in our project (blender). 
