### PR TITLE
[OpenCOLLADA] Maya2013 workaround for single face geometries

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaFileTranslator.cpp
+++ b/COLLADAMaya/src/COLLADAMayaFileTranslator.cpp
@@ -361,7 +361,7 @@ namespace COLLADAMaya
             if (ImportOptions::hasError()) status = MStatus::kFailure;
 
             // Import the COLLADA DAE file
-            status = importFromFile ( filename.asChar() );
+			status = importFromFile ( filename.asChar() );
         }
         catch ( COLLADABU::Exception* exception  )
         {
@@ -399,6 +399,7 @@ namespace COLLADAMaya
         mayaAsciiFileURI.setPathExtension ( ASCII_PATH_EXTENSION_DEBUG );
 #endif
         String mayaAsciiFileName = mayaAsciiFileURI.getURIString ();
+		const char* cpMayaAsciiFileName = mayaAsciiFileName.c_str();
 
         // Get the current maya version
         String mayaVersion ( MGlobal::mayaVersion ().asChar () );
@@ -414,8 +415,10 @@ namespace COLLADAMaya
         }
 
         // Actually import the document
-        DAE2MA::DocumentImporter documentImporter ( importFileName, mayaAsciiFileURI.getURIString (), mayaVersion.c_str () );
-        documentImporter.importCurrentScene ();
+		{
+			DAE2MA::DocumentImporter documentImporter ( importFileName, mayaAsciiFileURI.getURIString (), mayaVersion.c_str () );
+			documentImporter.importCurrentScene ();
+		}
 
         // Display some closing information.
         endClock = clock();
@@ -426,14 +429,14 @@ namespace COLLADAMaya
         std::cerr << message << std::endl;
 
         // TODO Open the maya ascii file in the maya instance
-        MFileIO::importFile ( mayaAsciiFileName.c_str () );
-        //MFileIO::open ( mayaAsciiFileName.c_str (), "mayaAscii", true ); 
+		MFileIO::importFile ( cpMayaAsciiFileName );
+		//MFileIO::open ( mayaAsciiFileName.c_str (), "mayaAscii", true ); 
 
-//         mayaAsciiFileURI.setPathExtension ( ".opencollada.mb" );
-//         mayaFileName = mayaAsciiFileURI.getURIString ();
-//         MFileIO::saveAs ( mayaFileName.c_str () );
-//         MGlobal::displayInfo ( "File saved as maya binary: " );
-//         MGlobal::displayInfo ( mayaFileName.c_str () 
+		//         mayaAsciiFileURI.setPathExtension ( ".opencollada.mb" );
+		//         mayaFileName = mayaAsciiFileURI.getURIString ();
+		//         MFileIO::saveAs ( mayaFileName.c_str () );
+		//         MGlobal::displayInfo ( "File saved as maya binary: " );
+		//         MGlobal::displayInfo ( mayaFileName.c_str () 
         
         return status;
     }
@@ -470,6 +473,7 @@ namespace COLLADAMaya
         return "dae";
     }
 
+	// ------------------------------
     MString FileTranslator::filter() const
     {
         return "*.dae;*.xml";

--- a/dae2ma/include/DAE2MADocumentImporter.h
+++ b/dae2ma/include/DAE2MADocumentImporter.h
@@ -261,6 +261,8 @@ namespace DAE2MA
         /** Destructor. */
         virtual ~DocumentImporter ();
 
+		const char* getMayaVersion() { return mMayaVersion; }
+
         /** Imports the current scene. */
         void importCurrentScene ();
 

--- a/dae2ma/include/DAE2MAGeometryImporter.h
+++ b/dae2ma/include/DAE2MAGeometryImporter.h
@@ -271,6 +271,8 @@ namespace DAE2MA
          */
         std::map<COLLADAFW::UniqueId, std::vector<GeometryShadingEngine> > mGeometryShadingEnginesMap;
 
+		size_t mCount2013Workarounds;
+
     public:
 
         /** Constructor. */
@@ -278,6 +280,8 @@ namespace DAE2MA
 
         /** Destructor. */
         virtual ~GeometryImporter ();
+
+		size_t getCount2013Workarounds() { return mCount2013Workarounds; }
 
         /** 
         * Imports the geometry element. 

--- a/dae2ma/src/DAE2MADocumentImporter.cpp
+++ b/dae2ma/src/DAE2MADocumentImporter.cpp
@@ -405,6 +405,10 @@ namespace DAE2MA
 
             // Close the file
             closeMayaAsciiFile ();
+
+			if( mGeometryImporter && mGeometryImporter->getCount2013Workarounds() > 0 )
+				std::cerr << "Warning: Maya 2013 workaround applied! (duplication of single face geometry!)" << std::endl;
+
         }
     }
 


### PR DESCRIPTION
- workaround for maya 2013 crash; caused by (valid!) geometries with single face (eg. one
  triangle/polygon)
- fixing trifan/tristrip normal handling if no normal indices available
