### PR TITLE
Fix smp building and remove references to includes that don't exist.

### DIFF
--- a/COLLADASaxFrameworkLoader/CMakeLists.txt
+++ b/COLLADASaxFrameworkLoader/CMakeLists.txt
@@ -265,6 +265,14 @@ set(TARGET_LIBS
 	${PCRE_LIBRARIES}
 )
 
+# For parallel building.
+if(USE_SHARED)
+    add_dependencies(GeneratedSaxParser_shared OpenCOLLADABaseUtils_shared)
+endif()
+if(USE_STATIC)
+    add_dependencies(GeneratedSaxParser_static OpenCOLLADABaseUtils_static)
+endif()
+
 if (USE_LIBXML)
 	list(APPEND libGeneratedSaxParser_include_dirs ${LIBXML2_INCLUDE_DIR})
 	list(APPEND TARGET_LIBS ${LIBXML2_LIBRARIES})

--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLPolygons.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLPolygons.h
@@ -12,7 +12,6 @@
 #define __COLLADASAXFWL_POLYGONS_H__
 
 #include "COLLADASaxFWLPHElement.h"
-#include "COLLADASaxFWLPolyBase.h"
 
 
 namespace COLLADASaxFWL

--- a/COLLADAStreamWriter/include/COLLADASWBuffer.h
+++ b/COLLADAStreamWriter/include/COLLADASWBuffer.h
@@ -13,8 +13,6 @@
 
 #include "COLLADASWPrerequisites.h"
 
-#include "COLLADASWIBufferFlusher.h"
-
 #include <string.h>
 
 namespace COLLADASW

--- a/Externals/MathMLSolver/include/MathMLParser.h
+++ b/Externals/MathMLSolver/include/MathMLParser.h
@@ -28,7 +28,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #include "MathMLSolverPrerequisites.h"
 #include <xercesc/parsers/XercesDOMParser.hpp>
-#include "MathMLParserHandler.h"
 #include "MathMLASTConstantExpression.h"
 
 namespace MathML

--- a/Externals/MathMLSolver/include/MathMLStreamParser.h
+++ b/Externals/MathMLSolver/include/MathMLStreamParser.h
@@ -29,7 +29,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 #include "MathMLSolverPrerequisites.h"
 #include <libxml/xmlreader.h>
 #include "MathMLStreamParserHandler.h"
-#include "MathMLParserHandler.h"
 #include "MathMLASTConstantExpression.h"
 
 #include <stack>

--- a/Externals/MathMLSolver/include/MathMLStreamParserHandler.h
+++ b/Externals/MathMLSolver/include/MathMLStreamParserHandler.h
@@ -28,7 +28,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 #include "MathMLSolverPrerequisites.h"
 #include <libxml/xmlreader.h>
-#include "MathMLParserHandler.h"
 #include "MathMLASTConstantExpression.h"
 
 #include <stack>


### PR DESCRIPTION
This is a partial commit of the patches I maintain for the official Fedora Linux package.

The others for unbundling libraries and setting a library soname could use more tweaking to make them acceptable upstream.
