### PR TITLE
Fix defect empty animation parameter name at the 1D animations.

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
@@ -1983,10 +1983,10 @@ namespace COLLADAMaya
         // for Bezier curves are used to store the control points.
         // 
         // In COLLADA, a geometry vector for BÈzier segment[i] is defined by:
-        // ÅEP0 is POSITION[i]
-        // ÅEC0 is OUT_TANGENT[i]
-        // ÅEC1 is IN_TANGENT[i+1]
-        // ÅEP1 is POSITION[i+1]
+        // ï P0 is POSITION[i]
+        // ï C0 is OUT_TANGENT[i]
+        // ï C1 is IN_TANGENT[i+1]
+        // ï P1 is POSITION[i+1]
         // 
         // A cubic BÈzier spline equation is given by:
         // B(s) = P0*(1-s)^3 + 3*C0*s*(1-s)^2 + 3*C1*s^2*(1-s) + P1*s^3


### PR DESCRIPTION
I think accessor's parameter needs parameter name.

Below is part of the collada_spec_1_4.pdf (P.38) accessor's details.

> The number and order of <param> elements define the output of the <accessor> element. Parameters
> are bound to values in the order in which both are specified. No reordering of the data can occur. A
> <param> element without a name attribute indicates that the value is not part of the output, so the element
> is unbound.
