### PR TITLE
Fix a defect of export node animation.

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
@@ -1979,10 +1979,10 @@ namespace COLLADAMaya
         // for Bezier curves are used to store the control points.
         // 
         // In COLLADA, a geometry vector for BÈzier segment[i] is defined by:
-        // ÅEP0 is POSITION[i]
-        // ÅEC0 is OUT_TANGENT[i]
-        // ÅEC1 is IN_TANGENT[i+1]
-        // ÅEP1 is POSITION[i+1]
+        // ï P0 is POSITION[i]
+        // ï C0 is OUT_TANGENT[i]
+        // ï C1 is IN_TANGENT[i+1]
+        // ï P1 is POSITION[i+1]
         // 
         // A cubic BÈzier spline equation is given by:
         // B(s) = P0*(1-s)^3 + 3*C0*s*(1-s)^2 + 3*C1*s^2*(1-s) + P1*s^3

--- a/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
@@ -1283,13 +1283,13 @@ namespace COLLADAMaya
         // Get the collada id.
         if ( node.hasFn ( MFn::kTransform ) )
         {
-            // Check if there is an extra attribute "colladaId" and use this as export id.
-            String nodeId;
-            MString attributeValue;
-            DagHelper::getPlugValue ( node, COLLADA_ID_ATTRIBUTE_NAME, attributeValue );
-            if ( attributeValue != EMPTY_CSTRING )
-                nodeId = mDocumentExporter->mayaNameToColladaName ( attributeValue, false );
-            else nodeId = mDocumentExporter->mayaNameToColladaName ( fnDagNode.name ().asChar () );
+            MDagPath dagPath;
+            fnDagNode.getPath( dagPath );
+            // The maya node id.
+            String mayaNodeId = mDocumentExporter->dagPathToColladaId ( dagPath );
+            
+            VisualSceneExporter* visualSceneExporter = mDocumentExporter->getVisualSceneExporter();
+            String nodeId = visualSceneExporter->findColladaNodeId( mayaNodeId );
             return nodeId;
         }
         // TODO Do we need it?
@@ -1979,10 +1979,10 @@ namespace COLLADAMaya
         // for Bezier curves are used to store the control points.
         // 
         // In COLLADA, a geometry vector for BÈzier segment[i] is defined by:
-        // ï P0 is POSITION[i]
-        // ï C0 is OUT_TANGENT[i]
-        // ï C1 is IN_TANGENT[i+1]
-        // ï P1 is POSITION[i+1]
+        // ÅEP0 is POSITION[i]
+        // ÅEC0 is OUT_TANGENT[i]
+        // ÅEC1 is IN_TANGENT[i+1]
+        // ÅEP1 is POSITION[i+1]
         // 
         // A cubic BÈzier spline equation is given by:
         // B(s) = P0*(1-s)^3 + 3*C0*s*(1-s)^2 + 3*C1*s^2*(1-s) + P1*s^3


### PR DESCRIPTION
If a scene has some same transform node name. The animation exporter exports same target id.
The animation exporter's node id decision method is not same as the visual scene exporter's method.