### PR TITLE
Fix for https://github.com/KhronosGroup/OpenCOLLADA/issues/207

### DIFF
--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLDocumentProcessor.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLDocumentProcessor.h
@@ -326,9 +326,11 @@ namespace COLLADASaxFWL
         /** Disable default assignment operator. */
 		const DocumentProcessor& operator= ( const DocumentProcessor& pre );
 
-
 		/** The version of the collada document.*/
 		void setCOLLADAVersion(COLLADAVersion cOLLADAVersion);
+
+		/** add joint for skin controller */
+		bool addValidatedJoint(const SidTreeNode &joint, NodeList &joints);
 	};
 
 } // namespace COLLADASAXFWL

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLDocumentProcessor.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLDocumentProcessor.cpp
@@ -322,27 +322,7 @@ namespace COLLADASaxFWL
 				const SidTreeNode* joint = resolveId( sidOrId );
 				if ( joint )
 				{
-					// the joint could be found
-					if ( joint->getTargetType() == SidTreeNode::TARGETTYPECLASS_OBJECT )
-					{
-						const COLLADAFW::Object* object = joint->getObjectTarget();
-
-						if ( object->getClassId() == COLLADAFW::Node::ID() )
-						{
-							joints.push_back( (COLLADAFW::Node*)object );
-
-							jointFound = true;
-							//search for the next joint
-						}
-						else
-						{
-							// we could resolve the sid, but is not a joint/node
-						}
-					}
-					else
-					{
-						// we could resolve the sid, but is not a joint/node
-					}
+					jointFound = addValidatedJoint(*joint, joints);
 				}
 			}
 			else if ( skeletonRoots.size() == 0 )
@@ -351,27 +331,7 @@ namespace COLLADASaxFWL
 				const SidTreeNode* joint = resolveSid( sidOrId );
 				if ( joint )
 				{
-					// the joint could be found
-					if ( joint->getTargetType() == SidTreeNode::TARGETTYPECLASS_OBJECT )
-					{
-						const COLLADAFW::Object* object = joint->getObjectTarget();
-
-						if ( object->getClassId() == COLLADAFW::Node::ID() )
-						{
-							joints.push_back( (COLLADAFW::Node*)object );
-
-							jointFound = true;
-							//search for the next joint
-						}
-						else
-						{
-							// we could resolve the sid, but is not a joint/node
-						}
-					}
-					else
-					{
-						// we could resolve the sid, but is not a joint/node
-					}
+					jointFound = addValidatedJoint(*joint, joints);
 				}
 			}
 			else
@@ -385,26 +345,11 @@ namespace COLLADASaxFWL
 					const SidTreeNode* joint = resolveSid( sidAddress );
 					if ( joint )
 					{
-						// the joint could be found
-						if ( joint->getTargetType() != SidTreeNode::TARGETTYPECLASS_OBJECT )
+						if( jointFound = addValidatedJoint(*joint, joints))
 						{
-							// we could resolve the sid, but is not a joint/node
+							//search for the next joint
 							break;
 						}
-
-						const COLLADAFW::Object* object = joint->getObjectTarget();
-
-						if ( object->getClassId() != COLLADAFW::Node::ID() )
-						{
-							// we could resolve the sid, but is not a joint/node
-							break;
-						}
-
-						joints.push_back( (COLLADAFW::Node*)object );
-
-						jointFound = true;
-						//search for the next joint
-						break;
 					}
 				}
 			}
@@ -496,6 +441,35 @@ namespace COLLADASaxFWL
 			}
 		}
 		return true;
+	}
+
+	//------------------------------
+	bool DocumentProcessor::addValidatedJoint(const SidTreeNode &joint, NodeList &joints)
+	{
+		bool jointValid = false;
+
+		// the joint could be found
+		if ( joint.getTargetType() == SidTreeNode::TARGETTYPECLASS_OBJECT )
+		{
+			const COLLADAFW::Object* object = joint.getObjectTarget();
+
+			if ( object->getClassId() == COLLADAFW::Node::ID() )
+			{
+				joints.push_back( (COLLADAFW::Node*)object );
+
+				jointValid = true;
+				//search for the next joint
+			}
+			else
+			{
+				// we could resolve the sid, but is not a joint/node
+			}
+		}
+		else
+		{
+			// we could resolve the sid, but is not a joint/node
+		}
+		return jointValid;
 	}
 
 	//------------------------------


### PR DESCRIPTION
Hello.
I believe this patch solves the issue mentioned in my post from 2 days ago.
I tested with the Blender Collada importer (development version) that the patch works as intended.
I refer to the Blender bug report (which includes an example file):

https://projects.blender.org/tracker/?func=detail&atid=498&aid=36325&group_id=9

Further notes:
The specification 1.4.1 does not tell that <skeleton> entries are mandatory. 
Furtherore the FBX Collada exporter doesn't generate <skeleton> entries for Library Controllers.
And finally Maya-2013 accepts the collada file and shows the model correctly.

Please can you commit, rework, or reject this patch in the near future ?
As soon as the patch is applied we can update the Blender Collada Importer as well.

Thanks for helping
Gaia
