### PR TITLE
Make import of Joint node hierarchies less strict

### DIFF
--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLNodeLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLNodeLoader.cpp
@@ -66,8 +66,6 @@ namespace COLLADASaxFWL
 				newNode->setSid( (const char*) attributeData.sid );
 			else if ( attributeData.id )
 				newNode->setSid( (const char*) attributeData.id );
-			else if ( attributeData.name )
-				newNode->setSid( (const char*) attributeData.name );
 		}
 
 		getHandlingFilePartLoader()->addToSidTree(attributeData.id, attributeData.sid, newNode);


### PR DESCRIPTION
This is a fix for fixing commit: 1a336bb

The above mentioned commit assumes that nodes of type joint always have an associated sid.
However i could not find any hint that sid is a required attribute for JOINT nodes.
Furthermore the "FBX COLLADA exporter" creates node hierarchies without sid's.
It uses the id attribute instead.

I prefer if the OpenCollada library is more tolerant to Collada files,
especially this particular case can be nicely auto fixed,
since i believe that we safely can use the attribue id
here as scoped id when no sid is specified.

note: I am not sure if the last fallback (use attributeData.name as node sid) is a good idea, so this last fallback can also be removed again if it doesn't make sense here.
