### PR TITLE
Correct spelling of windows.h

### DIFF
--- a/COLLADABaseUtils/src/COLLADABUNativeString.cpp
+++ b/COLLADABaseUtils/src/COLLADABUNativeString.cpp
@@ -16,7 +16,7 @@
 #include <string>
 
 #ifdef COLLADABU_OS_WIN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 namespace COLLADABU


### PR DESCRIPTION
With capital W, cross-compilation fails.
