### PR TITLE
Error messages for Collada Validate() functions. 

### DIFF
--- a/COLLADAFramework/include/COLLADAFWValidate.h
+++ b/COLLADAFramework/include/COLLADAFWValidate.h
@@ -21,11 +21,11 @@ namespace COLLADAFW
    
 	/** Validates an animation curve. 
 	@return True, if the animation is valid, false otherwise.*/
-	bool validate( const AnimationCurve* animationCurve );
+	int validate( const AnimationCurve* animationCurve, bool verbose );
 
 	/** Validates skin controller data. 
-	@return True, if the data is valid, false otherwise.*/
-	bool validate( const SkinControllerData* skinControllerData );
+	@return numberof found validation failures.*/
+	int validate( const SkinControllerData* skinControllerData, bool verbose );
 
 
 

--- a/COLLADAFramework/src/COLLADAFWValidate.cpp
+++ b/COLLADAFramework/src/COLLADAFWValidate.cpp
@@ -21,32 +21,51 @@ namespace COLLADAFW
 
 
 	//------------------------------
-	bool validate( const AnimationCurve* animationCurve )
+	int validate( const AnimationCurve* animationCurve, bool verbose )
 	{
+		int failure_count = 0;
 		if ( !animationCurve )
-			return false;
+			return 1;
 
 		size_t keyCount = animationCurve->getKeyCount();
 		size_t dimension = animationCurve->getOutDimension();
 
 		// We do not allow animations without keys
-		if ( keyCount == 0 )
-			return false;
+		if ( keyCount == 0 ){
+			if (verbose)
+				printf("ERROR: [%s] Animation curve has no keys.\n",
+				animationCurve->getName().c_str());
+			failure_count +=1;
+		}
 
 		// We do not allow animations with no out dimensions
-		if ( dimension == 0 )
-			return false;
+		if ( dimension == 0 ) {
+			if (verbose)
+				printf("ERROR: [%s] Animation curve has no dimension.\n",
+				animationCurve->getName().c_str());
+			failure_count +=1;
+		}
+
+		// Subsequent checks only make sense when above checks passed.
+		// Hence return now, if errors occured until here.
+		if (failure_count > 0)
+			return failure_count;
 
 		// for each key we need an input value
-		if ( animationCurve->getInputValues().getValuesCount() != keyCount )
-			return false;
+		if ( animationCurve->getInputValues().getValuesCount() != keyCount ) {
+			if (verbose)
+				printf("ERROR: [%s] Found %d input values for %d keys\n",
+				animationCurve->getName().c_str(),
+				animationCurve->getInputValues().getValuesCount(),
+				keyCount);
+			failure_count +=1;
+		}
 
 		size_t outValuesCount = dimension * keyCount;
 
 		// Check output values count
 		if ( animationCurve->getOutputValues().getValuesCount() != outValuesCount )
-			return false;
-
+			failure_count +=1;
 
 		bool needsTangents = ( animationCurve->getInterpolationType() == AnimationCurve::INTERPOLATION_BEZIER ) ||
 							 ( animationCurve->getInterpolationType() == AnimationCurve::INTERPOLATION_HERMITE );
@@ -54,8 +73,14 @@ namespace COLLADAFW
 		if ( animationCurve->getInterpolationType() == AnimationCurve::INTERPOLATION_MIXED )
 		{
 			// Check interpolations count
-			if ( animationCurve->getInterpolationTypes().getCount() != keyCount )
-				return false;
+			if ( animationCurve->getInterpolationTypes().getCount() != keyCount ) {
+				if (verbose)
+					printf("ERROR: [%s] Found %d interpolation types for %d keys\n",
+					animationCurve->getName().c_str(),
+					animationCurve->getInterpolationTypes().getCount(),
+					keyCount);
+				failure_count +=1;
+			}
 
 			// check if the animation must have tangent arrays
 			if ( !needsTangents )
@@ -75,8 +100,12 @@ namespace COLLADAFW
 		else
 		{
 			// Check interpolations count
-			if ( animationCurve->getInterpolationTypes().getCount() != 0 )
-				return false;
+			if ( animationCurve->getInterpolationTypes().getCount() != 0 ) {
+				if (verbose)
+					printf("ERROR: [%s] Found %d mixed interpolation types (expected only one type).\n",
+					animationCurve->getInterpolationTypes().getCount());
+				failure_count +=1;
+			}
 		}
 
 		size_t tangentCount = 0;
@@ -86,28 +115,48 @@ namespace COLLADAFW
 		}
 
 		// Check in tangents count
-		if ( animationCurve->getInTangentValues().getValuesCount() != tangentCount )
-			return false;
+		if ( animationCurve->getInTangentValues().getValuesCount() != tangentCount ) {
+				if (verbose)
+					printf("ERROR: [%s] Found %d IN tangent values for %d tangents\n",
+					animationCurve->getName().c_str(),
+					animationCurve->getInTangentValues().getValuesCount(),
+					tangentCount);
+			failure_count +=1;
+		}
 
 		// Check out tangents count
-		if ( animationCurve->getOutTangentValues().getValuesCount() != tangentCount )
-			return false;
+		if ( animationCurve->getOutTangentValues().getValuesCount() != tangentCount ) {
+				if (verbose)
+					printf("ERROR: [%s] Found %d OUT tangent values for %d tangents\n",
+					animationCurve->getName().c_str(),
+					animationCurve->getOutTangentValues().getValuesCount(),
+					tangentCount);
+			failure_count +=1;
+		}
 
-		return true;
+		return failure_count;
 	}
 
 
 	//------------------------------
-	bool validate( const SkinControllerData* skinControllerData )
+	int validate( const SkinControllerData* skinControllerData, bool verbose)
 	{
-		if ( !skinControllerData )
-			return false;
+		int failure_count = 0;
+		if ( !skinControllerData ) {
+			return 1;
+		}
 
 		size_t jointsCount = skinControllerData->getJointsCount();
 		size_t weightsCount = skinControllerData->getWeights().getValuesCount();
 
-		if ( skinControllerData->getInverseBindMatrices().getCount() != jointsCount )
-			return false;
+		if ( skinControllerData->getInverseBindMatrices().getCount() != jointsCount ) {
+			if (verbose)
+				printf("ERROR: [%s] found %d bind matrices and %d joints\n",
+				skinControllerData->getName().c_str(),
+				skinControllerData->getInverseBindMatrices().getCount(),
+				jointsCount);
+			failure_count +=1;
+		}
 	
 		const UIntValuesArray& jointsPerVertex = skinControllerData->getJointsPerVertex();
 
@@ -120,27 +169,53 @@ namespace COLLADAFW
 		// test weight indices
 		const UIntValuesArray& weightIndices = skinControllerData->getWeightIndices();
 
-		if ( jointsVertexPairCount != weightIndices.getCount() )
-			return false;
+		if ( jointsVertexPairCount != weightIndices.getCount() ) {
+			if (verbose)
+				printf("ERROR: [%s] found %d joint-Vertex Pairs and %d weights\n",
+				skinControllerData->getName().c_str(),
+				jointsVertexPairCount,
+				weightIndices.getCount());
+			failure_count +=1;
+		}
 
 		for ( size_t i = 0, count = weightIndices.getCount(); i < count; ++i)
 		{
-			if ( weightIndices[i] >= weightsCount)
-				return false;
+			if ( weightIndices[i] >= weightsCount) {
+				if (verbose)
+					printf("ERROR: [%s] weight index %d=%d points outside of weight array of length %d\n",
+					skinControllerData->getName().c_str(),
+					i,
+					weightIndices[i],
+					weightsCount);
+				failure_count +=1;
+			}
 		}
 
 		// test joint indices
 		const IntValuesArray& jointIndices = skinControllerData->getJointIndices();
 
-		if ( jointsVertexPairCount != jointIndices.getCount() )
-			return false;
+		if ( jointsVertexPairCount != jointIndices.getCount() ) {
+			if (verbose)
+				printf("ERROR: [%s] found %d joint-Vertex Pairs and %d joint indices\n",
+				skinControllerData->getName().c_str(),
+				jointsVertexPairCount,
+				jointIndices.getCount());
+			failure_count +=1;
+		}
 
 		for ( size_t i = 0, count = jointIndices.getCount(); i < count; ++i)
 		{
-			if ( (unsigned int)abs(jointIndices[i]) >= jointsCount)
-				return false;
+			if ( (unsigned int)abs(jointIndices[i]) >= jointsCount) {
+				if (verbose)
+					printf("ERROR: [%s] joint index %d=%d points outside of weight array of length %d\n",
+					skinControllerData->getName().c_str(),
+					i,
+					(unsigned int)abs(jointIndices[i]),
+					jointsCount);
+				failure_count +=1;
+			}
 		}
-		return true;
+		return failure_count;
 	}
 
 } // namespace COLLADAFW

--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryAnimationsLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryAnimationsLoader.h
@@ -59,6 +59,10 @@ namespace COLLADASaxFWL
 		to parse a sampler. This allows to not store tangents, if set to false.*/
 		bool mCurrentAnimationCurveRequiresTangents;
 
+		/** Used to control if validate function should report errors
+		or do its job silently */
+		bool mVerboseValidate;
+
 	public:
 
         /** Constructor. */

--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryControllersLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryControllersLoader.h
@@ -104,6 +104,10 @@ namespace COLLADASaxFWL
 		/** The index of the current matrix element, while parsing the bind_shape_matrix element.*/
 		size_t mCurrentMatrixIndex;
 
+		/** Used to control if validate function should report errors
+		or do its job silently */
+		bool mVerboseValidate;
+
 	public:
 
         /** Constructor. */

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryAnimationsLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryAnimationsLoader.cpp
@@ -283,6 +283,7 @@ namespace COLLADASaxFWL
 		, mCurrentlyParsingInterpolationArray(false)
 		, mCurrentAnimationInfo( 0 )
 		, mCurrentAnimationCurveRequiresTangents(true)
+		, mVerboseValidate(true)
 	{}
 
     //------------------------------
@@ -391,7 +392,7 @@ namespace COLLADASaxFWL
 				mCurrentAnimationCurve->setInterpolationType(COLLADAFW::AnimationCurve::INTERPOLATION_LINEAR );
 			}
 
-			if ( COLLADAFW::validate( mCurrentAnimationCurve ) )
+			if ( COLLADAFW::validate( mCurrentAnimationCurve, mVerboseValidate ) == 0)
 			{
 				success = writer()->writeAnimation(mCurrentAnimationCurve);
 				FW_DELETE mCurrentAnimationCurve;

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryControllersLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryControllersLoader.cpp
@@ -89,6 +89,7 @@ namespace COLLADASaxFWL
 		, mCurrentOffset(0)
 		, mCurrentBindShapeMatrix( COLLADABU::Math::Matrix4::IDENTITY)
 		, mCurrentMatrixIndex(0)
+		, mVerboseValidate(true)
 	{}
 
     //------------------------------
@@ -226,7 +227,7 @@ namespace COLLADASaxFWL
 	bool LibraryControllersLoader::end__skin()
 	{
 		bool success = true;
-		if ( validate( mCurrentSkinControllerData ) )
+		if ( validate( mCurrentSkinControllerData, mVerboseValidate ) == 0 )
 		{
 			success = writer()->writeSkinControllerData( mCurrentSkinControllerData );
 		}


### PR DESCRIPTION
This is a first proposal to improve the validation step in OpenCollada. Currently avalidation failure results in silent drop of the invalid data. With this patch the error is reported. I have also added a verbose flag for future use (currently set to true).

If this is a convenient proposal, then i can add 2 more features :

1.) Add a flag that controls "loose" vs."strict" validation. "

```
- "loose" would mean: the data is not consistent, but it probably could be imported.
- "strict" would mean: Report any inconsistency as "Error" and discard the data.
```

2.) Add the ability to control the validation type (strict/loose) and the verbosity from the API.

Here i would need some guideline how this should be implemented.
