### PR TITLE
Enable FreeBSD builds with libc++ (llvm) and clang

### DIFF
--- a/COLLADABaseUtils/include/COLLADABUPlatform.h
+++ b/COLLADABaseUtils/include/COLLADABUPlatform.h
@@ -23,7 +23,7 @@
 #  define COLLADABU_OS_WIN64
 #elif (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__))
 #  define COLLADABU_OS_WIN32
-#elif defined(__linux__) || defined(__linux)
+#elif defined(__linux__) || defined(__linux) || defined(__FreeBSD__)
 #  define COLLADABU_OS_LINUX
 #endif
 

--- a/COLLADABaseUtils/include/COLLADABUhash_map.h
+++ b/COLLADABaseUtils/include/COLLADABUhash_map.h
@@ -60,7 +60,16 @@
         #define COLLADABU_HASH_NAMESPACE_CLOSE }
         #define COLLADABU_HASH_FUN hash
     #endif
-#else   // Linux or Mac
+#elif defined(__FreeBSD__) && defined(_LIBCPP_VERSION)
+    #include <unordered_map>
+    #include <unordered_set>
+    #define COLLADABU_HASH_MAP std::unordered_map
+    #define COLLADABU_HASH_MULTIMAP std::unordered_multimap
+    #define COLLADABU_HASH_SET std::unordered_set
+    #define COLLADABU_HASH_NAMESPACE_OPEN std
+    #define COLLADABU_HASH_NAMESPACE_CLOSE
+    #define COLLADABU_HASH_FUN hash
+#else   // Linux or Mac or FreeBSD with GCC
     #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)
         #include <ext/hash_map>
         #include <ext/hash_set>

--- a/common/libBuffer/include/CommonFWriteBufferFlusher.h
+++ b/common/libBuffer/include/CommonFWriteBufferFlusher.h
@@ -35,6 +35,9 @@ namespace std {
 #ifdef __GNUC__
 #   include <cstdlib> /* size_t */
 #   include <cstdio>  /* FILE */
+#ifdef __FreeBSD__
+#include <stdint.h> /* int64_t */
+#endif
 #endif
 
 #if (defined(__GNUC__) && !defined(__STRICT_ANSI__) && !defined(__MINGW32__)) || (__STDC_VERSION__ >= 199901L)

--- a/common/libBuffer/src/CommonFWriteBufferFlusher.cpp
+++ b/common/libBuffer/src/CommonFWriteBufferFlusher.cpp
@@ -89,7 +89,7 @@ namespace Common
 		FilePosType currentPos = ftello64(mStream);
 #elif defined( _WIN32)
 		FilePosType currentPos = _ftelli64(mStream);
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) || defined(__FreeBSD__)
 		FilePosType currentPos = ftello(mStream);
 #else
 		FilePosType currentPos = ftello64(mStream);
@@ -114,7 +114,7 @@ namespace Common
   			return (fseeko64(mStream,0,SEEK_END) == 0);
 #elif defined( _WIN32)
 			return (_fseeki64(mStream, 0, SEEK_END) == 0);
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) || defined(__FreeBSD__)
 			return (fseeko(mStream, 0, SEEK_END) == 0);
 #else
 			return (fseeko64(mStream, 0, SEEK_END) == 0);
@@ -134,7 +134,7 @@ namespace Common
   				bool success = (fseeko64(mStream,pos,SEEK_SET) == 0);
 #elif defined( _WIN32)
 				bool success = (_fseeki64(mStream, pos, SEEK_SET) == 0);
-#elif defined (__APPLE__)
+#elif defined (__APPLE__) || defined(__FreeBSD__)
 				bool success = (fseeko(mStream, pos, SEEK_SET) == 0);
 #else
 				bool success = (fseeko64(mStream, pos, SEEK_SET) == 0);


### PR DESCRIPTION
- Enable FreeBSD builds
- Fix the build with clang and libc++ as default CXXSTD lib
