### PR TITLE
Include the <algorithm> header for std::min.

### DIFF
--- a/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
+++ b/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <string.h>
 #include <limits>
+#include <algorithm>
 
 namespace GeneratedSaxParser
 {


### PR DESCRIPTION
This fixes the build for Visual Studio 2013.
