### PR TITLE
allowing space in URL to work-around exporter issues

### DIFF
--- a/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
+++ b/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
@@ -867,8 +867,9 @@ namespace GeneratedSaxParser
             failed = false;
             return COLLADABU::URI(0);
         }
-        const ParserString& string = toStringListItem(buffer, bufferEnd, failed);
-        return COLLADABU::URI(string.str, string.length);
+        //const ParserString& string = toStringListItem(buffer, bufferEnd, failed);
+        //return COLLADABU::URI(string.str, string.length);
+        return COLLADABU::URI((const char*)*buffer, bufferEnd - *buffer);
     }
 
     //--------------------------------------------------------------------
@@ -879,8 +880,9 @@ namespace GeneratedSaxParser
             failed = false;
             return COLLADABU::URI(0);
         }
-        const ParserString& string = toStringListItem(buffer, failed);
-        return COLLADABU::URI(string.str, string.length);
+        //const ParserString& string = toStringListItem(buffer, failed);
+        //return COLLADABU::URI(string.str, string.length);
+        return COLLADABU::URI((const char*)*buffer);
     }
 
 


### PR DESCRIPTION
Unfortunately, collada exported by some tools including 3DS MAX may contain spaces in ids which are normally URLs. This patch just prevent the string being processed by toStringListItem which is actually a trim but also skip the remaining string after the first white space.
