### PR TITLE
Fixed Unit object to default to meters like the spec says.

### DIFF
--- a/COLLADAFramework/include/COLLADAFWFileInfo.h
+++ b/COLLADAFramework/include/COLLADAFWFileInfo.h
@@ -126,9 +126,9 @@ namespace COLLADAFW
         public:
 
             Unit ()
-                : mLinearUnitUnit ( CENTIMETER )
-                , mLinearUnitName ( LINEAR_UNIT_CENTIMETER_NAME )
-                , mLinearUnitMeter ( LINEAR_UNIT_CENTIMETER )
+                : mLinearUnitUnit ( METER )
+                , mLinearUnitName ( LINEAR_UNIT_METER_NAME )
+                , mLinearUnitMeter ( LINEAR_UNIT_METER )
                 , mAngularUnitName ( ANGULAR_UNIT_DEGREES_NAME )
                 , mAngularUnitUnit ( DEGREES )
                 , mTimeUnitName ( TIME_UNIT_FILM_NAME )


### PR DESCRIPTION
In the Collada 1.5.0 spec, page 5-18 and the 1.4.1 spec, page 5-17 it says that the default for the unit object is "meter=1.0" and name="meter".
