### PR TITLE
switch decay params (fixes #125)

### DIFF
--- a/COLLADAMax/src/COLLADAMaxLightExporter.cpp
+++ b/COLLADAMax/src/COLLADAMaxLightExporter.cpp
@@ -289,7 +289,7 @@ namespace COLLADAMax
 
 		if (isSpot || isPoint)
 		{
-			int decayFunction = parameters->GetInt(isPoint ? MaxLight::PB_DECAY : MaxLight::PB_OMNIDECAY, mDocumentExporter->getOptions().getAnimationStart());
+			int decayFunction = parameters->GetInt(isPoint ? MaxLight::PB_OMNIDECAY : MaxLight::PB_DECAY, mDocumentExporter->getOptions().getAnimationStart());
 			switch (decayFunction)
 			{
 			case 1:


### PR DESCRIPTION
I'm not sure about this but if "isPoint" means it's a point-light (= omni) then we should be using the omnidecay, not the other way around.
