### PR TITLE
Add missing includes to COLLADAFWInstanceBindingBase.h

### DIFF
--- a/COLLADAFramework/include/COLLADAFWInstanceBindingBase.h
+++ b/COLLADAFramework/include/COLLADAFWInstanceBindingBase.h
@@ -15,6 +15,11 @@
 #include "COLLADAFWInstanceBase.h"
 #include "COLLADAFWMaterialBinding.h"
 
+#include "COLLADABUURI.h"
+
+#include <vector>
+
+
 namespace COLLADAFW
 {
 


### PR DESCRIPTION
Trivial patch which adds two missing includes to `COLLADAFWInstanceBindingBase.h`. The lack of these caused blender build failures.
