### PR TITLE
Fix crashes with invalid XRefs

### DIFF
--- a/COLLADAMax/src/COLLADAMaxEffectExporter.cpp
+++ b/COLLADAMax/src/COLLADAMaxEffectExporter.cpp
@@ -40,6 +40,9 @@
 #include <shaders.h>
 #include <imtl.h> 
 
+
+#include "COLLADASWException.h"
+
 namespace COLLADAMax
 {
 
@@ -179,9 +182,13 @@ namespace COLLADAMax
 			}
 			else
 			{
-				assert(false);
-//				xRefedMaterialList.push_back(mat);
-				return;
+				std::ostringstream err;
+				err << "Failed to get XRef for this material:\n";
+				err << material->GetName();
+				err << "\napplied for this object:\n";
+				err << exportNode->getId();
+
+				throw COLLADASW::StreamWriterException(err.str());
 			}
 		}
 

--- a/COLLADAMax/src/COLLADAMaxXRefFunctions.cpp
+++ b/COLLADAMax/src/COLLADAMaxXRefFunctions.cpp
@@ -23,6 +23,8 @@
 #include <max.h>
 #include "COLLADAMaxXRefIncludes.h"
 
+#include "COLLADASWException.h"
+
 namespace COLLADAMax
 {
 
@@ -165,6 +167,12 @@ namespace COLLADAMax
 		// resolve nested
 		IDerivedObject* source = (IDerivedObject*) xRefObjectInterface->GetSrcItem(false);
 		
+
+		//If failed to get XRef data
+		if (!source){
+			throw COLLADASW::StreamWriterException(COLLADASW::StreamWriterException::ERROR_TYPE_UNKNOWN, "Failed to resolve XRef");
+		}
+
 		INode* bb1 = source->GetWorldSpaceObjectNode();
 
 


### PR DESCRIPTION
3ds max OpenCollada exporter plugin crashes when exporting scene containing broken XRefs.
Crashes occur because of null pointer dereferencing.
Here is probable solution. Any comments and feedback would be highly appreciated.
Thanks for attention.