### PR TITLE
Visual scene node extra attributes export

### DIFF
--- a/COLLADAMaya/COLLADAMaya.xcodeproj/project.pbxproj
+++ b/COLLADAMaya/COLLADAMaya.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		24FFE6D314A526D600D718C2 /* COLLADAFWInstanceKinematicsScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 24FFE6CF14A526CF00D718C2 /* COLLADAFWInstanceKinematicsScene.h */; };
 		873516D81AC99C0A009300AC /* COLLADAMayaShaderFXShaderExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 873516D71AC99C0A009300AC /* COLLADAMayaShaderFXShaderExporter.cpp */; };
 		8776CF011AC9975C00032EE7 /* COLLADAMayaShaderFXShaderExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8776CF001AC9975C00032EE7 /* COLLADAMayaShaderFXShaderExporter.h */; };
+		879D18E01AE8070F005C246C /* COLLADAMayaAttributeParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 879D18DF1AE8070F005C246C /* COLLADAMayaAttributeParser.h */; };
+		879D18E21AE8071E005C246C /* COLLADAMayaAttributeParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 879D18E11AE8071E005C246C /* COLLADAMayaAttributeParser.cpp */; };
 		A5155E1619F795D800D5D4DC /* COLLADAMaya.bundle in CopyFiles */ = {isa = PBXBuildFile; fileRef = D2AAC09D05546B4700DB518D /* COLLADAMaya.bundle */; };
 		CE0B3D8A0F56AF48004F8570 /* COLLADASWAsset.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE0B3D570F56AF48004F8570 /* COLLADASWAsset.cpp */; };
 		CE0B3D8B0F56AF48004F8570 /* COLLADASWBaseElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE0B3D580F56AF48004F8570 /* COLLADASWBaseElement.cpp */; };
@@ -922,6 +924,8 @@
 		24FFE6CF14A526CF00D718C2 /* COLLADAFWInstanceKinematicsScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COLLADAFWInstanceKinematicsScene.h; path = ../COLLADAFramework/include/COLLADAFWInstanceKinematicsScene.h; sourceTree = "<group>"; };
 		873516D71AC99C0A009300AC /* COLLADAMayaShaderFXShaderExporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COLLADAMayaShaderFXShaderExporter.cpp; path = src/COLLADAMayaShaderFXShaderExporter.cpp; sourceTree = "<group>"; };
 		8776CF001AC9975C00032EE7 /* COLLADAMayaShaderFXShaderExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COLLADAMayaShaderFXShaderExporter.h; path = include/COLLADAMayaShaderFXShaderExporter.h; sourceTree = "<group>"; };
+		879D18DF1AE8070F005C246C /* COLLADAMayaAttributeParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COLLADAMayaAttributeParser.h; path = include/COLLADAMayaAttributeParser.h; sourceTree = "<group>"; };
+		879D18E11AE8071E005C246C /* COLLADAMayaAttributeParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COLLADAMayaAttributeParser.cpp; path = src/COLLADAMayaAttributeParser.cpp; sourceTree = "<group>"; };
 		CE0B3D570F56AF48004F8570 /* COLLADASWAsset.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COLLADASWAsset.cpp; path = ../COLLADAStreamWriter/src/COLLADASWAsset.cpp; sourceTree = SOURCE_ROOT; };
 		CE0B3D580F56AF48004F8570 /* COLLADASWBaseElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COLLADASWBaseElement.cpp; path = ../COLLADAStreamWriter/src/COLLADASWBaseElement.cpp; sourceTree = SOURCE_ROOT; };
 		CE0B3D590F56AF48004F8570 /* COLLADASWBaseInputElement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COLLADASWBaseInputElement.cpp; path = ../COLLADAStreamWriter/src/COLLADASWBaseInputElement.cpp; sourceTree = SOURCE_ROOT; };
@@ -2343,6 +2347,7 @@
 		CE72910410AC800500AE5662 /* source */ = {
 			isa = PBXGroup;
 			children = (
+				879D18E11AE8071E005C246C /* COLLADAMayaAttributeParser.cpp */,
 				CE72914610ACA1F800AE5662 /* COLLADAMayaAnimationClipExporter.cpp */,
 				CE72914710ACA1F800AE5662 /* COLLADAMayaAnimationCurves.cpp */,
 				CE72914810ACA1F800AE5662 /* COLLADAMayaAnimationElement.cpp */,
@@ -2384,6 +2389,7 @@
 		CE72910510AC800C00AE5662 /* include */ = {
 			isa = PBXGroup;
 			children = (
+				879D18DF1AE8070F005C246C /* COLLADAMayaAttributeParser.h */,
 				CE0B3E9C0F56AFD8004F8570 /* COLLADAMayaAnimationClipExporter.h */,
 				CE0B3E9D0F56AFD8004F8570 /* COLLADAMayaAnimationCurves.h */,
 				CE0B3E9E0F56AFD8004F8570 /* COLLADAMayaAnimationElement.h */,
@@ -3434,6 +3440,7 @@
 				CE0B3F0A0F56AFD8004F8570 /* COLLADAMayaSyntax.h in Headers */,
 				CE0B3F0B0F56AFD8004F8570 /* COLLADAMayaTangentPoint.h in Headers */,
 				CE0B3F0C0F56AFD8004F8570 /* COLLADAMayaVisualSceneExporter.h in Headers */,
+				879D18E01AE8070F005C246C /* COLLADAMayaAttributeParser.h in Headers */,
 				CE4A34C90F98E47A00E32945 /* COLLADAMayaVersionInfo.h in Headers */,
 				CE7D40150FF1308D00849CFA /* COLLADAMayaBaseAnimation.h in Headers */,
 				CE7D40160FF1308E00849CFA /* COLLADAMayaMayaTransform.h in Headers */,
@@ -4078,6 +4085,7 @@
 				CE72917E10ACA1F800AE5662 /* COLLADAMayaImportOptions.cpp in Sources */,
 				CE72917F10ACA1F800AE5662 /* COLLADAMayaLightExporter.cpp in Sources */,
 				CE72918010ACA1F800AE5662 /* COLLADAMayaMaterialExporter.cpp in Sources */,
+				879D18E21AE8071E005C246C /* COLLADAMayaAttributeParser.cpp in Sources */,
 				CE72918110ACA1F800AE5662 /* COLLADAMayaPrecompiledHeaders.cpp in Sources */,
 				CE72918210ACA1F800AE5662 /* COLLADAMayaReferenceManager.cpp in Sources */,
 				CE72918310ACA1F800AE5662 /* COLLADAMayaRotateHelper.cpp in Sources */,

--- a/COLLADAMaya/include/COLLADAMayaAttributeParser.h
+++ b/COLLADAMaya/include/COLLADAMayaAttributeParser.h
@@ -1,0 +1,92 @@
+/*
+    Copyright (c) 2008-2009 NetAllied Systems GmbH
+
+	This file is part of COLLADAMaya.
+
+    Portions of the code are:
+    Copyright (c) 2005-2007 Feeling Software Inc.
+    Copyright (c) 2005-2007 Sony Computer Entertainment America
+    Copyright (c) 2004-2005 Alias Systems Corp.
+
+    Licensed under the MIT Open Source License,
+    for details please see LICENSE file or the website
+    http://www.opensource.org/licenses/mit-license.php
+*/
+
+#ifndef __COLLADA_MAYA_ATTRIBUTE_PARSER_H__
+#define __COLLADA_MAYA_ATTRIBUTE_PARSER_H__
+
+#include "COLLADAMayaPrerequisites.h"
+#include "COLLADAMayaPlatform.h"
+
+#include <maya/MFnDependencyNode.h>
+#include <maya/MFnNumericData.h>
+
+namespace COLLADAMaya
+{
+
+	/**
+	 * Helper class used to parse a node's attributes.
+	 */
+    class AttributeParser
+    {
+	public:
+
+		/**
+		 * Parse attributes of fnNode and call corresponding callbacks of AttributeParser object.
+		 * @param fnNode Parsed node
+		 * @param parser Object inheriting AttributeParser class and implementing some of the onXXX() methods.
+		 */
+		static MStatus parseAttributes(MFnDependencyNode & fnNode, AttributeParser & parser);
+
+	protected:
+		/**
+		 * Callback called before parsing an attribute.
+		 * @param fnNode Parsed node.
+		 * @param attribute Parsed attribute.
+		 * @return MStatus::kFailure to skip attribute. MStatus::kSuccess to continue attribute parsing.
+		 */
+		virtual MStatus onBeforeAttribute	(MFnDependencyNode & fnNode, MObject & attribute)			{ return MS::kSuccess; }
+
+		/**
+		 * Callback called after parsing an attribute.
+		 * @param fnNode Parsed node.
+		 * @param attribute Parsed attribute.
+		 */
+		virtual MStatus onAfterAttribute	(MFnDependencyNode & fnNode, MObject & attribute)			{ return MS::kSuccess; }
+
+		/**
+		 * Callbacks called when parsing an attribute of given type.
+		 * @param plug Node plug associated to current attribute.
+		 * @param name Current attribute name.
+		 * @param value Current attribute plug value.
+		 */
+		virtual MStatus onBoolean			(MPlug & plug, const MString & name, bool value)			{ return MS::kSuccess; }
+		virtual MStatus onByte				(MPlug & plug, const MString & name, char value)			{ return MS::kSuccess; }
+		virtual MStatus onChar				(MPlug & plug, const MString & name, char value)			{ return MS::kSuccess; }
+		virtual MStatus onShort				(MPlug & plug, const MString & name, short value)			{ return MS::kSuccess; }
+		virtual MStatus onShort2			(MPlug & plug, const MString & name, short value[2])		{ return MS::kSuccess; }
+		virtual MStatus onShort3			(MPlug & plug, const MString & name, short value[3])		{ return MS::kSuccess; }
+		virtual MStatus onLong				(MPlug & plug, const MString & name, int value)				{ return MS::kSuccess; }
+		virtual MStatus onLong2				(MPlug & plug, const MString & name, int value[2])			{ return MS::kSuccess; }
+		virtual MStatus onLong3				(MPlug & plug, const MString & name, int value[3])			{ return MS::kSuccess; }
+		virtual MStatus onFloat				(MPlug & plug, const MString & name, float value)			{ return MS::kSuccess; }
+		virtual MStatus onFloat2			(MPlug & plug, const MString & name, float value[2])		{ return MS::kSuccess; }
+		virtual MStatus onFloat3			(MPlug & plug, const MString & name, float value[3])		{ return MS::kSuccess; }
+		virtual MStatus onDouble			(MPlug & plug, const MString & name, double value)			{ return MS::kSuccess; }
+		virtual MStatus onDouble2			(MPlug & plug, const MString & name, double value[2])		{ return MS::kSuccess; }
+		virtual MStatus onDouble3			(MPlug & plug, const MString & name, double value[3])		{ return MS::kSuccess; }
+		virtual MStatus onDouble4			(MPlug & plug, const MString & name, double value[4])		{ return MS::kSuccess; }
+		virtual MStatus onString			(MPlug & plug, const MString & name, const MString & value)	{ return MS::kSuccess; }
+
+	private:
+		MStatus parseAttribute			(MFnDependencyNode & fnNode, MObject & attribute);
+		MStatus parseNumericAttribute	(MFnDependencyNode & fnNode, MObject & attribute);
+		MStatus parseTypedAttribute		(MFnDependencyNode & fnNode, MObject & attribute);
+		MStatus parseNumericData		(MFnDependencyNode & fnNode, MObject & attribute);
+		MStatus parseNumeric			(MPlug plug, MFnNumericData::Type type);
+		MStatus parseStringData			(MFnDependencyNode & fnNode, MObject & attribute);
+    };
+}
+
+#endif // __COLLADA_MAYA_ATTRIBUTE_PARSER_H__

--- a/COLLADAMaya/include/COLLADAMayaShaderFXShaderExporter.h
+++ b/COLLADAMaya/include/COLLADAMayaShaderFXShaderExporter.h
@@ -31,6 +31,8 @@ namespace COLLADAMaya
 
 	class ShaderFXShaderExporter
     {
+		friend class ShaderFXAttributeExporter;
+		friend class ShaderFXSamplerAndSurfaceExporter;
 
     private:
 
@@ -66,12 +68,6 @@ namespace COLLADAMaya
 
 		void exportSamplerAndSurface(const MFnDependencyNode & node, const MObject & attr);
 		void exportSamplerAndSurfaceInner(const MString & filename);
-		void exportAttribute(const MFnDependencyNode & node, const MObject & attr);
-		void exportNumericAttribute(const MFnDependencyNode & node, const MObject & attr);
-		void exportTypedAttribute(const MFnDependencyNode & node, const MObject & attr);
-		void exportNumericData(const MFnDependencyNode & node, const MObject & attr);
-		void exportNumeric(MPlug plug, MFnNumericData::Type type);
-		void exportStringData(const MFnDependencyNode & node, const MObject & attr);
 		void exportTexture(const MString & filename);
     };
 }

--- a/COLLADAMaya/include/COLLADAMayaVisualSceneExporter.h
+++ b/COLLADAMaya/include/COLLADAMayaVisualSceneExporter.h
@@ -276,6 +276,12 @@ namespace COLLADAMaya
          */
         void exportVisibility ( COLLADASW::Node* sceneNode );
 
+		/**
+		 * Exports all extra attributes.
+		 * @param sceneNode The collada scene node to export the attributes.
+		 */
+		void exportExtraAttributes(const SceneElement* sceneElement);
+
         /**
          * @todo documentation
          * @param sceneElement

--- a/COLLADAMaya/scripts/COLLADAMaya.vcxproj
+++ b/COLLADAMaya/scripts/COLLADAMaya.vcxproj
@@ -2819,6 +2819,7 @@ copy "$(ProjectDir)*.mel" "%25MAYA_PATH2012_X64%25\scripts\others"
     <ClCompile Include="..\src\COLLADAMayaEffectExporter.cpp" />
     <ClCompile Include="..\src\COLLADAMayaEffectTextureExporter.cpp" />
     <ClCompile Include="..\src\COLLADAMayaExportOptions.cpp" />
+    <ClCompile Include="..\src\COLLADAMayaAttributeParser.cpp" />
     <ClCompile Include="..\src\COLLADAMayaFileTranslator.cpp" />
     <ClCompile Include="..\src\COLLADAMayaGeometryExporter.cpp" />
     <ClCompile Include="..\src\COLLADAMayaGeometryPolygonExporter.cpp" />
@@ -2899,6 +2900,7 @@ copy "$(ProjectDir)*.mel" "%25MAYA_PATH2012_X64%25\scripts\others"
     <ClInclude Include="..\include\COLLADAMayaEffectExporter.h" />
     <ClInclude Include="..\include\COLLADAMayaEffectTextureExporter.h" />
     <ClInclude Include="..\include\COLLADAMayaExportOptions.h" />
+    <ClInclude Include="..\include\COLLADAMayaAttributeParser.h" />
     <ClInclude Include="..\include\COLLADAMayaFileTranslator.h" />
     <ClInclude Include="..\include\COLLADAMayaGeometryExporter.h" />
     <ClInclude Include="..\include\COLLADAMayaGeometryPolygonExporter.h" />

--- a/COLLADAMaya/scripts/COLLADAMaya.vcxproj.filters
+++ b/COLLADAMaya/scripts/COLLADAMaya.vcxproj.filters
@@ -164,6 +164,9 @@
     <ClCompile Include="..\src\COLLADAMayaShaderFXShaderExporter.cpp">
       <Filter>Source Files\Exporters</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\COLLADAMayaAttributeParser.cpp">
+      <Filter>Source Files\Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\include\COLLADAMayaConversion.h">
@@ -291,6 +294,9 @@
     </ClInclude>
     <ClInclude Include="..\include\COLLADAMayaShaderFXShaderExporter.h">
       <Filter>Header Files\Exporters</Filter>
+    </ClInclude>
+    <ClInclude Include="..\include\COLLADAMayaAttributeParser.h">
+      <Filter>Header Files\Helpers</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/COLLADAMaya/src/COLLADAMayaAttributeParser.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAttributeParser.cpp
@@ -154,10 +154,12 @@ namespace COLLADAMaya
 			// TODO
 			break;
 
+#if MAYA_API_VERSION >= 201400
 			//! Float Array, use MFnFloatArrayData to extract the node data.
 		case MFnData::kFloatArray:
 			// TODO
 			break;
+#endif
 
 			//! Int Array, use MFnIntArrayData to extract the node data.
 		case MFnData::kIntArray:
@@ -232,10 +234,12 @@ namespace COLLADAMaya
 			// TODO
 			break;
 
+#if MAYA_API_VERSION >= 201200
 			//! Typically used when the data can be one of several types.
 		case MFnData::kAny:
 			// TODO
 			break;
+#endif
 
 		default:
 			break;

--- a/COLLADAMaya/src/COLLADAMayaAttributeParser.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAttributeParser.cpp
@@ -1,0 +1,530 @@
+/*
+    Copyright (c) 2008-2009 NetAllied Systems GmbH
+
+	This file is part of COLLADAMaya.
+
+    Portions of the code are:
+    Copyright (c) 2005-2007 Feeling Software Inc.
+    Copyright (c) 2005-2007 Sony Computer Entertainment America
+    Copyright (c) 2004-2005 Alias Systems Corp.
+
+    Licensed under the MIT Open Source License,
+    for details please see LICENSE file or the website
+    http://www.opensource.org/licenses/mit-license.php
+*/
+
+#include "COLLADAMayaStableHeaders.h"
+#include "COLLADAMayaAttributeParser.h"
+
+#include <maya/MFnAttribute.h>
+#include <maya/MFnNumericAttribute.h>
+#include <maya/MFnNumericData.h>
+#include <maya/MFnTypedAttribute.h>
+
+namespace COLLADAMaya
+{
+	MStatus AttributeParser::parseAttributes(MFnDependencyNode & fnNode, AttributeParser & parser)
+	{
+		MStatus status;
+		unsigned int attrCount = fnNode.attributeCount(&status);
+		for (unsigned int attrIndex = 0; attrIndex < attrCount; ++attrIndex)
+		{
+			MObject attrObject = fnNode.attribute(attrIndex, &status);
+			MFnAttribute fnAttr(attrObject, &status);
+			if (!status) continue;
+
+			MString attrName = fnAttr.name(&status);
+
+			if (!parser.onBeforeAttribute(fnNode, attrObject))
+				continue;
+
+			parser.parseAttribute(fnNode, attrObject);
+
+			//if (!parser.onAfterAttribute(fnNode, attrObject))
+			//	continue;
+			parser.onAfterAttribute(fnNode, attrObject);
+		}
+
+		return MS::kSuccess;
+	}
+
+	MStatus AttributeParser::parseAttribute(MFnDependencyNode & node, MObject & attr)
+	{
+		MStatus status;
+
+		MFnAttribute fnAttr(attr, &status);
+		if (!status) return status;
+
+		MString attrName = fnAttr.name(&status);
+		if (!status) return status;
+
+		if (attr.hasFn(MFn::kCompoundAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kEnumAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kGenericAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kLightDataAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kMatrixAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kMessageAttribute)) {
+			// TODO
+		}
+		else if (attr.hasFn(MFn::kNumericAttribute)) {
+			return parseNumericAttribute(node, attr);
+		}
+		else if (attr.hasFn(MFn::kTypedAttribute)) {
+			return parseTypedAttribute(node, attr);
+		}
+		else if (attr.hasFn(MFn::kUnitAttribute)) {
+			// TODO
+		}
+		return MS::kSuccess;
+	}
+
+	MStatus AttributeParser::parseNumericAttribute(MFnDependencyNode & node, MObject & attr)
+	{
+		MStatus status;
+		MFnNumericAttribute fnNumAttr(attr, &status);
+		if (!status) return status;
+
+		MFnNumericData::Type type = fnNumAttr.unitType(&status);
+		if (!status) return status;
+
+		MPlug plug = node.findPlug(attr, &status);
+		if (!status) return status;
+
+		return parseNumeric(plug, type);
+	}
+
+	MStatus AttributeParser::parseTypedAttribute(MFnDependencyNode & node, MObject & attr)
+	{
+		MStatus status;
+
+		MFnTypedAttribute fnTypedAttr(attr, &status);
+		if (!status) return status;
+
+		MFnData::Type type = fnTypedAttr.attrType(&status);
+		if (!status) return status;
+
+		switch (type)
+		{
+			//! Invalid value
+		case MFnData::kInvalid:
+			break;
+
+			//! Numeric, use MFnNumericData extract the node data.
+		case MFnData::kNumeric:
+			return parseNumericData(node, attr);
+			break;
+
+			//! Plugin Blind Data, use MFnPluginData to extract the node data.
+		case MFnData::kPlugin:
+			// TODO
+			break;
+
+			//! Plugin Geometry, use MFnGeometryData to extract the node data.
+		case MFnData::kPluginGeometry:
+			// TODO
+			break;
+
+			//! String, use MFnStringData to extract the node data.
+		case MFnData::kString:
+			return parseStringData(node, attr);
+			break;
+
+			//! Matrix, use MFnMatrixData to extract the node data.
+		case MFnData::kMatrix:
+			// TODO
+			break;
+
+			//! String Array, use MFnStringArrayData to extract the node data.
+		case MFnData::kStringArray:
+			// TODO
+			break;
+
+			//! Double Array, use MFnDoubleArrayData to extract the node data.
+		case MFnData::kDoubleArray:
+			// TODO
+			break;
+
+			//! Float Array, use MFnFloatArrayData to extract the node data.
+		case MFnData::kFloatArray:
+			// TODO
+			break;
+
+			//! Int Array, use MFnIntArrayData to extract the node data.
+		case MFnData::kIntArray:
+			// TODO
+			break;
+
+			//! Point Array, use MFnPointArrayData to extract the node data.
+		case MFnData::kPointArray:
+			// TODO
+			break;
+
+			//! Vector Array, use MFnVectorArrayData to extract the node data.
+		case MFnData::kVectorArray:
+			// TODO
+			break;
+
+			//! Component List, use MFnComponentListData to extract the node data.
+		case MFnData::kComponentList:
+			// TODO
+			break;
+
+			//! Mesh, use MFnMeshData to extract the node data.
+		case MFnData::kMesh:
+			// TODO
+			break;
+
+			//! Lattice, use MFnLatticeData to extract the node data.
+		case MFnData::kLattice:
+			// TODO
+			break;
+
+			//! Nurbs Curve, use MFnNurbsCurveData to extract the node data.
+		case MFnData::kNurbsCurve:
+			// TODO
+			break;
+
+			//! Nurbs Surface, use MFnNurbsSurfaceData to extract the node data.
+		case MFnData::kNurbsSurface:
+			// TODO
+			break;
+
+			//! Sphere, use MFnSphereData to extract the node data.
+		case MFnData::kSphere:
+			// TODO
+			break;
+
+			//! ArrayAttrs, use MFnArrayAttrsData to extract the node data.
+		case MFnData::kDynArrayAttrs:
+			// TODO
+			break;
+
+			/*! SweptGeometry, use MFnDynSweptGeometryData to extract the
+			node data. This data node is in OpenMayaFX which must be
+			linked to.
+			*/
+		case MFnData::kDynSweptGeometry:
+			// TODO
+			break;
+
+			//! Subdivision Surface, use MFnSubdData to extract the node data.
+		case MFnData::kSubdSurface:
+			// TODO
+			break;
+
+			//! nObject data, use MFnNObjectData to extract node data
+		case MFnData::kNObject:
+			// TODO
+			break;
+
+			//! nId data, use MFnNIdData to extract node data
+		case MFnData::kNId:
+			// TODO
+			break;
+
+			//! Typically used when the data can be one of several types.
+		case MFnData::kAny:
+			// TODO
+			break;
+
+		default:
+			break;
+		}
+		return MS::kSuccess;
+	}
+
+	MStatus AttributeParser::parseNumericData(MFnDependencyNode & node, MObject & attr)
+	{
+		MStatus status;
+
+		MFnNumericData fnNumericData(attr, &status);
+		if (!status) return status;
+
+		MPlug plug = node.findPlug(attr, &status);
+		if (!status) return status;
+
+		MFnNumericData::Type type = fnNumericData.numericType(&status);
+
+		return parseNumeric(plug, type);
+	}
+
+	MStatus AttributeParser::parseNumeric(MPlug plug, MFnNumericData::Type type)
+	{
+		MStatus status;
+
+		MObject attrObj = plug.attribute(&status);
+		if (!status) return status;
+
+		MFnAttribute attr(attrObj, &status);
+		if (!status) return status;
+
+		MString name = attr.name(&status);
+		if (!status) return status;
+
+		switch (type)
+		{
+		case MFnNumericData::kInvalid:			//!< Invalid data.
+			break;
+		case MFnNumericData::kBoolean:			//!< Boolean.
+		{
+			bool value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onBoolean(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kByte:				//!< One byte.
+		{
+			char value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onByte(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kChar:				//!< One character.
+		{
+			char value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onChar(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kShort:				//!< One short.
+		{
+			short value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onShort(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k2Short:			//!< Two shorts.
+		{
+			MStatus status;
+			short value[2];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			return onShort2(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k3Short:			//!< Three shorts.
+		{
+			MStatus status;
+			short value[3];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			MPlug plug2 = plug.child(2, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			status = plug2.getValue(value[2]);
+			if (!status) return status;
+			return onShort3(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kLong:				//!< One long. Same as int since "long" is not platform-consistent.
+		{
+			int value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onLong(plug, name, value);
+		}
+		break;
+		//case MFnNumericData::Type::kInt:		//!< One int.
+		//	break;
+		case MFnNumericData::k2Long:				//!< Two longs. Same as 2 ints since "long" is not platform-consistent.
+		{
+			MStatus status;
+			int value[2];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			return onLong2(plug, name, value);
+		}
+		break;
+		//case MFnNumericData::Type::k2Int:		//!< Two ints.
+		//	break;
+		case MFnNumericData::k3Long:				//!< Three longs. Same as 3 ints since "long" is not platform-consistent.
+		{
+			MStatus status;
+			int value[3];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			MPlug plug2 = plug.child(2, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			status = plug2.getValue(value[2]);
+			if (!status) return status;
+			return onLong3(plug, name, value);
+		}
+		break;
+		//case MFnNumericData::Type::k3Int:		//!< Three ints.
+		//	break;
+		case MFnNumericData::kFloat:				//!< One float.
+		{
+			float value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onFloat(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k2Float:			//!< Two floats.
+		{
+			MStatus status;
+			float value[2];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			return onFloat2(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k3Float:			//!< Three floats.
+		{
+			MStatus status;
+			float value[3];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			MPlug plug2 = plug.child(2, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			status = plug2.getValue(value[2]);
+			if (!status) return status;
+			return onFloat3(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kDouble:			//!< One double.
+		{
+			double value;
+			MStatus status = plug.getValue(value);
+			if (!status) return status;
+			return onDouble(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k2Double:			//!< Two doubles.
+		{
+			MStatus status;
+			double value[2];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			return onDouble2(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k3Double:			//!< Three doubles.
+		{
+			MStatus status;
+			double value[3];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			MPlug plug2 = plug.child(2, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			status = plug2.getValue(value[2]);
+			if (!status) return status;
+			return onDouble3(plug, name, value);
+		}
+		break;
+		case MFnNumericData::k4Double:			//!< Four doubles.
+		{
+			MStatus status;
+			double value[4];
+			MPlug plug0 = plug.child(0, &status);
+			if (!status) return status;
+			MPlug plug1 = plug.child(1, &status);
+			if (!status) return status;
+			MPlug plug2 = plug.child(2, &status);
+			if (!status) return status;
+			MPlug plug3 = plug.child(3, &status);
+			if (!status) return status;
+			status = plug0.getValue(value[0]);
+			if (!status) return status;
+			status = plug1.getValue(value[1]);
+			if (!status) return status;
+			status = plug2.getValue(value[2]);
+			if (!status) return status;
+			status = plug3.getValue(value[3]);
+			if (!status) return status;
+			return onDouble4(plug, name, value);
+		}
+		break;
+		case MFnNumericData::kAddr:				//!< An address.
+			// TODO
+			break;
+		default:
+			break;
+		}
+		return MS::kSuccess;
+	}
+
+	MStatus AttributeParser::parseStringData(MFnDependencyNode & node, MObject & attr)
+	{
+		MStatus status;
+
+		MPlug plug = node.findPlug(attr, &status);
+		if (!status) return status;
+
+		MString value;
+		status = plug.getValue(value);
+		if (!status) return status;
+
+		if (value.length() == 0)
+			return MS::kFailure;
+
+		MFnAttribute fnAttr(attr, &status);
+		if (!status) return status;
+
+		MString name = fnAttr.name(&status);
+		if (!status) return status;
+		
+		return onString(plug, name, value);
+	}
+}

--- a/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
@@ -432,7 +432,8 @@ namespace COLLADAMaya
 			ScopedEffectProfile profile(mEffectProfile);
 			{
 				// Export samplers and surfaces
-				AttributeParser::parseAttributes(shaderNode, ShaderFXSamplerAndSurfaceExporter(*this));
+                ShaderFXSamplerAndSurfaceExporter SamplerAndSurfaceExporter(*this);
+				AttributeParser::parseAttributes(shaderNode, SamplerAndSurfaceExporter);
 
 				// Open a <extra><technique> section
 				ScopedExtraTechnique extraTechnique(mStreamWriter, PROFILE_MAYA);
@@ -441,7 +442,8 @@ namespace COLLADAMaya
 					ScopedElement shaderfx(mStreamWriter, SHADERFX);
 
 					// Parse attributes and export them
-					AttributeParser::parseAttributes(shaderNode, ShaderFXAttributeExporter(*this));
+                    ShaderFXAttributeExporter attributeExporter(*this);
+					AttributeParser::parseAttributes(shaderNode, attributeExporter);
 				}
 			}
 		}

--- a/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
@@ -186,6 +186,8 @@ namespace COLLADAMaya
 				return MS::kFailure;
 
 			mShaderFXExporter.exportSamplerAndSurfaceInner(value);
+
+			return MS::kSuccess;
 		}
 	};
 

--- a/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaShaderFXShaderExporter.cpp
@@ -20,6 +20,7 @@
 #include "COLLADAMayaShaderFXShaderExporter.h"
 #include "COLLADAMayaEffectExporter.h"
 #include "COLLADAMayaSyntax.h"
+#include "COLLADAMayaAttributeParser.h"
 
 #include <maya/MFnAttribute.h>
 #include <maya/MFnNumericAttribute.h>
@@ -137,6 +138,263 @@ namespace COLLADAMaya
 		COLLADASW::StreamWriter & mStreamWriter;
 	};
 
+	// ------------------------------------------------------------------------
+
+	class ShaderFXSamplerAndSurfaceExporter : public AttributeParser
+	{
+	public:
+		ShaderFXSamplerAndSurfaceExporter(ShaderFXShaderExporter & shaderFXExporter)
+			: mShaderFXExporter(shaderFXExporter)
+		{}
+
+	private:
+		ShaderFXShaderExporter & mShaderFXExporter;
+
+	protected:
+		virtual MStatus onBeforeAttribute(MFnDependencyNode & node, MObject & attr)
+		{
+			MStatus status;
+			MFnAttribute fnAttr(attr, &status);
+			if (!status) return status;
+
+			MString attrName = fnAttr.name(&status);
+			if (!status) return status;
+
+			// Skip irrelevant attributes
+			if (shouldSkipAttribute(attrName))
+				return MS::kFailure;
+
+			return MS::kSuccess;
+		}
+
+	protected:
+		virtual MStatus onString(MPlug & plug, const MString & name, const MString & value)
+		{
+			MStatus status;
+
+			if (value.length() == 0)
+				return MS::kFailure;
+
+			MObject attr = plug.attribute(&status);
+			if (!status) return status;
+
+			bool isUsedAsFilename = MFnAttribute(attr).isUsedAsFilename(&status);
+			if (!status) return MS::kFailure;
+
+			// Filename are treated as texture filenames.
+			if (!isUsedAsFilename)
+				return MS::kFailure;
+
+			mShaderFXExporter.exportSamplerAndSurfaceInner(value);
+		}
+	};
+
+	class ShaderFXAttributeExporter : public AttributeParser
+	{
+	public:
+		ShaderFXAttributeExporter(ShaderFXShaderExporter & shaderFXExporter)
+			: mShaderFXExporter(shaderFXExporter)
+		{}
+
+	private:
+		ShaderFXShaderExporter & mShaderFXExporter;
+
+	protected:
+		virtual MStatus onBeforeAttribute(MFnDependencyNode & node, MObject & attr)
+		{
+			MStatus status;
+			MFnAttribute fnAttr(attr, &status);
+			if (!status) return status;
+
+			MString attrName = fnAttr.name(&status);
+			if (!status) return status;
+
+			// Skip irrelevant attributes
+			if (shouldSkipAttribute(attrName))
+				return MS::kFailure;
+
+			mShaderFXExporter.mStreamWriter.openElement(SHADERFX_ATTRIBUTE);
+			mShaderFXExporter.mStreamWriter.appendAttribute("name", attrName.asChar());
+
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onAfterAttribute(MFnDependencyNode & fnNode, MObject & attribute)
+		{
+			mShaderFXExporter.mStreamWriter.closeElement();
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onBoolean(MPlug & plug, const MString & name, bool value)
+		{
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_BOOLEAN);
+			mShaderFXExporter.mStreamWriter.appendText(value ? SHADERFX_TRUE : SHADERFX_FALSE);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onByte(MPlug & plug, const MString & name, char value)
+		{
+			char text[5];
+			sprintf(text, "0x%X", value);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_BYTE);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onChar(MPlug & plug, const MString & name, char value)
+		{
+			char text[2] = { value, '\0' };
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_BYTE);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onShort(MPlug & plug, const MString & name, short value)
+		{
+			char text[512];
+			sprintf(text, "%i", value);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_SHORT);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onShort2(MPlug & plug, const MString & name, short value[2])
+		{
+			char text[512];
+			sprintf(text, "%i %i", value[0], value[1]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_SHORT2);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onShort3(MPlug & plug, const MString & name, short value[3])
+		{
+			char text[512];
+			sprintf(text, "%i %i %i", value[0], value[1], value[2]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_SHORT3);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onLong(MPlug & plug, const MString & name, int value)
+		{
+			char text[512];
+			sprintf(text, "%i", value);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_LONG);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onLong2(MPlug & plug, const MString & name, int value[2])
+		{
+			char text[512];
+			sprintf(text, "%i %i", value[0], value[1]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_LONG2);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onLong3(MPlug & plug, const MString & name, int value[3])
+		{
+			char text[512];
+			sprintf(text, "%i %i %i", value[0], value[1], value[2]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_LONG3);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onFloat(MPlug & plug, const MString & name, float value)
+		{
+			char text[512];
+			sprintf(text, "%f", value);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_FLOAT);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onFloat2(MPlug & plug, const MString & name, float value[2])
+		{
+			char text[512];
+			sprintf(text, "%f %f", value[0], value[1]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_FLOAT2);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onFloat3(MPlug & plug, const MString & name, float value[3])
+		{
+			char text[512];
+			sprintf(text, "%f %f %f", value[0], value[1], value[2]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_FLOAT3);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onDouble(MPlug & plug, const MString & name, double value)
+		{
+			char text[512];
+			sprintf(text, "%f", value);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_DOUBLE);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onDouble2(MPlug & plug, const MString & name, double value[2])
+		{
+			char text[512];
+			sprintf(text, "%f %f", value[0], value[1]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_DOUBLE2);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onDouble3(MPlug & plug, const MString & name, double value[3])
+		{
+			char text[512];
+			sprintf(text, "%f %f %f", value[0], value[1], value[2]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_DOUBLE3);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onDouble4(MPlug & plug, const MString & name, double value[4])
+		{
+			char text[512];
+			sprintf(text, "%f %f %f %f", value[0], value[1], value[2], value[3]);
+			ScopedElement element(mShaderFXExporter.mStreamWriter, SHADERFX_DOUBLE4);
+			mShaderFXExporter.mStreamWriter.appendText(text);
+			return MS::kSuccess;
+		}
+
+		virtual MStatus onString(MPlug & plug, const MString & name, const MString & value)
+		{
+			MStatus status;
+
+			MObject attr = plug.attribute(&status);
+			if (!status) return status;
+
+			if (value.length() == 0)
+				return MS::kFailure;
+
+			bool isUsedAsFilename = MFnAttribute(attr).isUsedAsFilename(&status);
+			if (!status) return MS::kFailure;
+
+			// Filename are treated as texture filenames.
+			if (isUsedAsFilename)
+			{
+				// Export texture
+				mShaderFXExporter.exportTexture(value);
+			}
+			else
+			{
+				// Export string
+				ScopedElement string(mShaderFXExporter.mStreamWriter, SHADERFX_STRING);
+				mShaderFXExporter.mStreamWriter.appendText(value.asChar());
+			}
+			return MS::kSuccess;
+		}
+	};
+
     // ------------------------------------------------------------------------
 
 	ShaderFXShaderExporter::ShaderFXShaderExporter(DocumentExporter & documentExporter, COLLADASW::EffectProfile & effectProfile, const String & effectId)
@@ -146,31 +404,6 @@ namespace COLLADAMaya
 		, mTextureIndex(0)
 		, mEffectId(effectId)
 	{}
-
-	template<typename Method>
-	void ShaderFXShaderExporter::parseAttributes(const MFnDependencyNode & shaderNode, Method method)
-	{
-		MStatus status;
-		unsigned int attrCount = shaderNode.attributeCount(&status);
-		for (unsigned int attrIndex = 0; attrIndex < attrCount; ++attrIndex)
-		{
-			MObject attrObject = shaderNode.attribute(attrIndex, &status);
-			MFnAttribute fnAttr(attrObject, &status);
-			if (!status) continue;
-
-			MString attrName = fnAttr.name(&status);
-
-			// Skip irrelevant attributes
-			if (shouldSkipAttribute(attrName))
-				continue;
-
-			// Get node plug for current attribute 
-			MPlug plug = shaderNode.findPlug(attrObject, &status);
-			if (!status) continue;
-
-			(this->*method)(shaderNode, attrObject);
-		}
-	}
 
 	void ShaderFXShaderExporter::exportShaderFXShader(MObject & shaderObject )
     {
@@ -199,7 +432,7 @@ namespace COLLADAMaya
 			ScopedEffectProfile profile(mEffectProfile);
 			{
 				// Export samplers and surfaces
-				parseAttributes(shaderNode, &ShaderFXShaderExporter::exportSamplerAndSurface);
+				AttributeParser::parseAttributes(shaderNode, ShaderFXSamplerAndSurfaceExporter(*this));
 
 				// Open a <extra><technique> section
 				ScopedExtraTechnique extraTechnique(mStreamWriter, PROFILE_MAYA);
@@ -208,526 +441,11 @@ namespace COLLADAMaya
 					ScopedElement shaderfx(mStreamWriter, SHADERFX);
 
 					// Parse attributes and export them
-					parseAttributes(shaderNode, &ShaderFXShaderExporter::exportAttribute);
+					AttributeParser::parseAttributes(shaderNode, ShaderFXAttributeExporter(*this));
 				}
 			}
 		}
     }
-
-	void ShaderFXShaderExporter::exportAttribute(const MFnDependencyNode & node, const MObject & attr)
-	{
-		MStatus status;
-
-		MFnAttribute fnAttr(attr, &status);
-		if (!status) return;
-
-		MString attrName = fnAttr.name(&status);
-		if (!status) return;
-
-		ScopedElement attribute(mStreamWriter, SHADERFX_ATTRIBUTE);
-		mStreamWriter.appendAttribute("name", attrName.asChar());
-		{
-			if (attr.hasFn(MFn::kCompoundAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kEnumAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kGenericAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kLightDataAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kMatrixAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kMessageAttribute)) {
-				// TODO
-			}
-			else if (attr.hasFn(MFn::kNumericAttribute)) {
-				exportNumericAttribute(node, attr);
-			}
-			else if (attr.hasFn(MFn::kTypedAttribute)) {
-				exportTypedAttribute(node, attr);
-			}
-			else if (attr.hasFn(MFn::kUnitAttribute)) {
-				// TODO
-			}
-		}
-	}
-
-	void ShaderFXShaderExporter::exportNumericAttribute(const MFnDependencyNode & node, const MObject & attr)
-	{
-		MStatus status;
-		MFnNumericAttribute fnNumAttr(attr, &status);
-		if (!status) return;
-
-		MFnNumericData::Type type = fnNumAttr.unitType(&status);
-		if (!status) return;
-
-		MPlug plug = node.findPlug(attr, &status);
-		if (!status) return;
-
-		exportNumeric(plug, type);
-	}
-
-	void ShaderFXShaderExporter::exportTypedAttribute(const MFnDependencyNode & node, const MObject & attr)
-	{
-		MStatus status;
-
-		MFnTypedAttribute fnTypedAttr(attr, &status);
-		if (!status) return;
-
-		MFnData::Type type = fnTypedAttr.attrType(&status);
-		if (!status) return;
-
-		switch (type)
-		{
-			//! Invalid value
-        case MFnData::kInvalid:
-			break;
-
-			//! Numeric, use MFnNumericData extract the node data.
-		case MFnData::kNumeric:
-			exportNumericData(node, attr);
-			break;
-
-			//! Plugin Blind Data, use MFnPluginData to extract the node data.
-		case MFnData::kPlugin:
-			// TODO
-			break;
-
-			//! Plugin Geometry, use MFnGeometryData to extract the node data.
-		case MFnData::kPluginGeometry:
-			// TODO
-			break;
-
-			//! String, use MFnStringData to extract the node data.
-		case MFnData::kString:
-			exportStringData(node, attr);
-			break;
-
-			//! Matrix, use MFnMatrixData to extract the node data.
-		case MFnData::kMatrix:
-			// TODO
-			break;
-
-			//! String Array, use MFnStringArrayData to extract the node data.
-		case MFnData::kStringArray:
-			// TODO
-			break;
-
-			//! Double Array, use MFnDoubleArrayData to extract the node data.
-		case MFnData::kDoubleArray:
-			// TODO
-			break;
-
-			//! Float Array, use MFnFloatArrayData to extract the node data.
-		case MFnData::kFloatArray:
-			// TODO
-			break;
-
-			//! Int Array, use MFnIntArrayData to extract the node data.
-		case MFnData::kIntArray:
-			// TODO
-			break;
-
-			//! Point Array, use MFnPointArrayData to extract the node data.
-		case MFnData::kPointArray:
-			// TODO
-			break;
-
-			//! Vector Array, use MFnVectorArrayData to extract the node data.
-		case MFnData::kVectorArray:
-			// TODO
-			break;
-
-			//! Component List, use MFnComponentListData to extract the node data.
-		case MFnData::kComponentList:
-			// TODO
-			break;
-
-			//! Mesh, use MFnMeshData to extract the node data.
-		case MFnData::kMesh:
-			// TODO
-			break;
-
-			//! Lattice, use MFnLatticeData to extract the node data.
-		case MFnData::kLattice:
-			// TODO
-			break;
-
-			//! Nurbs Curve, use MFnNurbsCurveData to extract the node data.
-		case MFnData::kNurbsCurve:
-			// TODO
-			break;
-
-			//! Nurbs Surface, use MFnNurbsSurfaceData to extract the node data.
-		case MFnData::kNurbsSurface:
-			// TODO
-			break;
-
-			//! Sphere, use MFnSphereData to extract the node data.
-		case MFnData::kSphere:
-			// TODO
-			break;
-
-			//! ArrayAttrs, use MFnArrayAttrsData to extract the node data.
-		case MFnData::kDynArrayAttrs:
-			// TODO
-			break;
-
-			/*! SweptGeometry, use MFnDynSweptGeometryData to extract the
-			node data. This data node is in OpenMayaFX which must be
-			linked to.
-			*/
-		case MFnData::kDynSweptGeometry:
-			// TODO
-			break;
-
-			//! Subdivision Surface, use MFnSubdData to extract the node data.
-		case MFnData::kSubdSurface:
-			// TODO
-			break;
-
-			//! nObject data, use MFnNObjectData to extract node data
-		case MFnData::kNObject:
-			// TODO
-			break;
-
-			//! nId data, use MFnNIdData to extract node data
-		case MFnData::kNId:
-			// TODO
-			break;
-
-			//! Typically used when the data can be one of several types.
-		case MFnData::kAny:
-			// TODO
-			break;
-
-		default:
-			break;
-		}
-	}
-
-	void ShaderFXShaderExporter::exportNumericData(const MFnDependencyNode & node, const MObject & attr)
-	{
-		MStatus status;
-
-		MFnNumericData fnNumericData(attr, &status);
-		if (!status) return;
-
-		MPlug plug = node.findPlug(attr, &status);
-		if (!status) return;
-
-		MFnNumericData::Type type = fnNumericData.numericType(&status);
-
-		exportNumeric(plug, type);
-	}
-
-	void ShaderFXShaderExporter::exportNumeric(MPlug plug, MFnNumericData::Type type)
-	{
-		MStatus status;
-
-		switch (type)
-		{
-		case MFnNumericData::kInvalid:			//!< Invalid data.
-			break;
-		case MFnNumericData::kBoolean:			//!< Boolean.
-		{
-			bool value;
-			status = plug.getValue(value);
-			if (!status) return;
-			ScopedElement element(mStreamWriter, SHADERFX_BOOLEAN);
-			mStreamWriter.appendText(value ? SHADERFX_TRUE : SHADERFX_FALSE);
-		}
-		break;
-		case MFnNumericData::kByte:				//!< One byte.
-		{
-			char value;
-			status = plug.getValue(value);
-			if (!status) return;
-			char text[5];
-			sprintf(text, "0x%X", value);
-			ScopedElement element(mStreamWriter, SHADERFX_BYTE);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::kChar:				//!< One character.
-		{
-			char text[2] = { '\0' };
-			status = plug.getValue(text[0]);
-			if (!status) return;
-			ScopedElement element(mStreamWriter, SHADERFX_BYTE);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::kShort:				//!< One short.
-		{
-			short value;
-			status = plug.getValue(value);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i", value);
-			ScopedElement element(mStreamWriter, SHADERFX_SHORT);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k2Short:			//!< Two shorts.
-		{
-			short value[2];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i %i", value[0], value[1]);
-			ScopedElement element(mStreamWriter, SHADERFX_SHORT2);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k3Short:			//!< Three shorts.
-		{
-			short value[3];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			MPlug plug2 = plug.child(2, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			status = plug2.getValue(value[2]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i %i %i", value[0], value[1], value[2]);
-			ScopedElement element(mStreamWriter, SHADERFX_SHORT3);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::kLong:				//!< One long. Same as int since "long" is not platform-consistent.
-		{
-			int value;
-			status = plug.getValue(value);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i", value);
-			ScopedElement element(mStreamWriter, SHADERFX_LONG);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		//case MFnNumericData::Type::kInt:		//!< One int.
-		//	break;
-		case MFnNumericData::k2Long:				//!< Two longs. Same as 2 ints since "long" is not platform-consistent.
-		{
-			int value[2];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i %i", value[0], value[1]);
-			ScopedElement element(mStreamWriter, SHADERFX_LONG2);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		//case MFnNumericData::Type::k2Int:		//!< Two ints.
-		//	break;
-		case MFnNumericData::k3Long:				//!< Three longs. Same as 3 ints since "long" is not platform-consistent.
-		{
-			int value[3];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			MPlug plug2 = plug.child(2, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			status = plug2.getValue(value[2]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%i %i %i", value[0], value[1], value[2]);
-			ScopedElement element(mStreamWriter, SHADERFX_LONG3);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		//case MFnNumericData::Type::k3Int:		//!< Three ints.
-		//	break;
-		case MFnNumericData::kFloat:				//!< One float.
-		{
-			float value;
-			status = plug.getValue(value);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f", value);
-			ScopedElement element(mStreamWriter, SHADERFX_FLOAT);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k2Float:			//!< Two floats.
-		{
-			float value[2];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f %f", value[0], value[1]);
-			ScopedElement element(mStreamWriter, SHADERFX_FLOAT2);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k3Float:			//!< Three floats.
-		{
-			float value[3];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			MPlug plug2 = plug.child(2, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			status = plug2.getValue(value[2]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f %f %f", value[0], value[1], value[2]);
-			ScopedElement element(mStreamWriter, SHADERFX_FLOAT3);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::kDouble:			//!< One double.
-		{
-			double value;
-			status = plug.getValue(value);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f", value);
-			ScopedElement element(mStreamWriter, SHADERFX_DOUBLE);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k2Double:			//!< Two doubles.
-		{
-			double value[2];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f %f", value[0], value[1]);
-			ScopedElement element(mStreamWriter, SHADERFX_DOUBLE2);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k3Double:			//!< Three doubles.
-		{
-			double value[3];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			MPlug plug2 = plug.child(2, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			status = plug2.getValue(value[2]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f %f %f", value[0], value[1], value[2]);
-			ScopedElement element(mStreamWriter, SHADERFX_DOUBLE3);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::k4Double:			//!< Four doubles.
-		{
-			double value[4];
-			MPlug plug0 = plug.child(0, &status);
-			if (!status) return;
-			MPlug plug1 = plug.child(1, &status);
-			if (!status) return;
-			MPlug plug2 = plug.child(2, &status);
-			if (!status) return;
-			MPlug plug3 = plug.child(3, &status);
-			if (!status) return;
-			status = plug0.getValue(value[0]);
-			if (!status) return;
-			status = plug1.getValue(value[1]);
-			if (!status) return;
-			status = plug2.getValue(value[2]);
-			if (!status) return;
-			status = plug3.getValue(value[3]);
-			if (!status) return;
-			char text[512];
-			sprintf(text, "%f %f %f %f", value[0], value[1], value[2], value[3]);
-			ScopedElement element(mStreamWriter, SHADERFX_DOUBLE4);
-			mStreamWriter.appendText(text);
-		}
-		break;
-		case MFnNumericData::kAddr:				//!< An address.
-			// TODO
-			break;
-		default:
-			break;
-		}
-	}
-
-	void ShaderFXShaderExporter::exportStringData(const MFnDependencyNode & node, const MObject & attr)
-	{
-		MStatus status;
-
-		MPlug plug = node.findPlug(attr, &status);
-		if (!status) return;
-
-		MString value;
-		status = plug.getValue(value);
-		if (!status) return;
-
-		if (value.length() == 0)
-			return;
-
-		bool isUsedAsFilename = MFnAttribute(attr).isUsedAsFilename(&status);
-		if (!status) return;
-
-		// Filename are treated as texture filenames.
-		if (isUsedAsFilename)
-		{
-			// Export texture
-			exportTexture(value);
-		}
-		else
-		{
-			// Export string
-			ScopedElement string(mStreamWriter, SHADERFX_STRING);
-			mStreamWriter.appendText(value.asChar());
-		}
-	}
 
 	void ShaderFXShaderExporter::exportSamplerAndSurface(const MFnDependencyNode & node, const MObject & attr)
 	{

--- a/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
@@ -1119,7 +1119,7 @@ namespace COLLADAMaya
 
 			virtual MStatus onBoolean(MPlug & plug, const MString & name, bool value)
 			{
-				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), value);
 				return MS::kSuccess;
 			}
 
@@ -1137,7 +1137,7 @@ namespace COLLADAMaya
 
 			virtual MStatus onShort(MPlug & plug, const MString & name, short value)
 			{
-				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), value);
 				return MS::kSuccess;
 			}
 
@@ -1155,7 +1155,7 @@ namespace COLLADAMaya
 
 			virtual MStatus onLong(MPlug & plug, const MString & name, int value)
 			{
-				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), value);
 				return MS::kSuccess;
 			}
 
@@ -1173,7 +1173,7 @@ namespace COLLADAMaya
 
 			virtual MStatus onFloat(MPlug & plug, const MString & name, float value)
 			{
-				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), value);
 				return MS::kSuccess;
 			}
 
@@ -1191,7 +1191,7 @@ namespace COLLADAMaya
 
 			virtual MStatus onDouble(MPlug & plug, const MString & name, double value)
 			{
-				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), value);
 				return MS::kSuccess;
 			}
 

--- a/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
@@ -1226,7 +1226,8 @@ namespace COLLADAMaya
 		MFnDependencyNode fnNode(nodeObject, &status);
 		if (!status) return;
 
-		AttributeParser::parseAttributes(fnNode, ExtraAttributeExporter(*mVisualSceneNode));
+        ExtraAttributeExporter extraAttributeExporter(*mVisualSceneNode);
+		AttributeParser::parseAttributes(fnNode, extraAttributeExporter);
 	}
 
     //---------------------------------------------------------------

--- a/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
@@ -30,6 +30,7 @@
 #include "COLLADAMayaCameraExporter.h"
 #include "COLLADAMayaEffectExporter.h"
 #include "COLLADAMayaShaderHelper.h"
+#include "COLLADAMayaAttributeParser.h"
 
 #include <maya/MFnIkHandle.h>
 #include <maya/MFnSkinCluster.h>
@@ -40,6 +41,7 @@
 #include <maya/MDagPath.h>
 #include <maya/MFnCamera.h>
 #include <maya/MFileIO.h>
+#include <maya/MFnAttribute.h>
 
 #include "COLLADASWNode.h"
 #include "COLLADASWInstanceGeometry.h"
@@ -630,6 +632,8 @@ namespace COLLADAMaya
             mVisualSceneNode->addExtraTechniqueParameter ( PROFILE_MAYA, PARAMETER_MAYA_ID, nodeName );
         }
 
+		exportExtraAttributes(sceneElement);
+
         // TODO Export the imported extra tags, if there exist some.
         
 
@@ -1069,6 +1073,161 @@ namespace COLLADAMaya
             }
         }
     }
+
+	//---------------------------------------------------------------
+	void VisualSceneExporter::exportExtraAttributes(const SceneElement* sceneElement)
+	{
+		class ExtraAttributeExporter : public AttributeParser
+		{
+		public:
+			ExtraAttributeExporter(COLLADASW::Node & visualSceneNode)
+				: mVisualSceneNode(visualSceneNode)
+			{}
+
+		private:
+			COLLADASW::Node & mVisualSceneNode;
+
+		protected:
+			virtual MStatus onBeforeAttribute(MFnDependencyNode & node, MObject & attr)
+			{
+				MStatus status;
+				MFnAttribute fnAttr(attr, &status);
+				if (!status) return status;
+
+				MString attrName = fnAttr.name(&status);
+				if (!status) return status;
+
+				bool isDynamic = fnAttr.isDynamic(&status);
+				if (!status) return status;
+
+				if (!isDynamic)
+					return MS::kFailure;
+
+				bool isHidden = fnAttr.isHidden(&status);
+				if (!status) return status;
+
+				if (isHidden)
+					return MS::kFailure;
+
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onAfterAttribute(MFnDependencyNode & fnNode, MObject & attribute)
+			{
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onBoolean(MPlug & plug, const MString & name, bool value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onByte(MPlug & plug, const MString & name, char value)
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onChar(MPlug & plug, const MString & name, char value)
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onShort(MPlug & plug, const MString & name, short value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onShort2(MPlug & plug, const MString & name, short value[2])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onShort3(MPlug & plug, const MString & name, short value[3])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onLong(MPlug & plug, const MString & name, int value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onLong2(MPlug & plug, const MString & name, int value[2])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onLong3(MPlug & plug, const MString & name, int value[3])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onFloat(MPlug & plug, const MString & name, float value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onFloat2(MPlug & plug, const MString & name, float value[2])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onFloat3(MPlug & plug, const MString & name, float value[3])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onDouble(MPlug & plug, const MString & name, double value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, name.asChar(), value);
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onDouble2(MPlug & plug, const MString & name, double value[2])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onDouble3(MPlug & plug, const MString & name, double value[3])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onDouble4(MPlug & plug, const MString & name, double value[4])
+			{
+				// TODO
+				return MS::kSuccess;
+			}
+
+			virtual MStatus onString(MPlug & plug, const MString & name, const MString & value)
+			{
+				mVisualSceneNode.addExtraTechniqueParameter(PROFILE_MAYA, String(name.asChar()), String(value.asChar()));
+				return MS::kSuccess;
+			}
+		};
+
+		MObject nodeObject = sceneElement->getNode();
+		
+		MStatus status;
+		MFnDependencyNode fnNode(nodeObject, &status);
+		if (!status) return;
+
+		AttributeParser::parseAttributes(fnNode, ExtraAttributeExporter(*mVisualSceneNode));
+	}
 
     //---------------------------------------------------------------
     void VisualSceneExporter::exportInstanceController(


### PR DESCRIPTION
Note: only supports common types like float, int, string, float3 etc... and visual scene nodes.