### PR TITLE
Add optional attributes name and id to instance_geometry nodes

### DIFF
--- a/COLLADAStreamWriter/include/COLLADASWInstanceGeometry.h
+++ b/COLLADAStreamWriter/include/COLLADASWInstanceGeometry.h
@@ -34,7 +34,15 @@ namespace COLLADASW
         /** The URL of the location of the object to instantiate.*/
         URI mUrl;
 
-    public:
+		/** A text string containing the name of the <instance_geometry> element. Optional. */
+		String mName;
+
+		/** A text string containing the unique identifier of the <instance_geometry>
+		element. This value must be unique within the instance document.
+		Optional. */
+		String mId;
+
+	public:
 
 		/** Constructor
 		@param The stream the instance geometry should be written to
@@ -56,6 +64,30 @@ namespace COLLADASW
         {
             return mUrl;
         }
+
+		/** Returns a reference to the instance geometry id*/
+		const String& getId() const 
+		{
+			return mId;
+		}
+
+		/** Sets the id of the element*/
+		void setId(const String& id)
+		{
+			mId = id;
+		}
+
+		/** A text string containing the name of the <instance_geometry> element. Optional. */
+		const String getName() const 
+		{ 
+			return mName; 
+		}
+
+		/** A text string containing the name of the <instance_geometry> element. Optional. */
+		void setName(const String name) 
+		{ 
+			mName = name; 
+		}
 
         BindMaterial& getBindMaterial()
         {

--- a/COLLADAStreamWriter/src/COLLADASWInstanceGeometry.cpp
+++ b/COLLADAStreamWriter/src/COLLADASWInstanceGeometry.cpp
@@ -20,6 +20,12 @@ namespace COLLADASW
         mSW->openElement ( CSWC::CSW_ELEMENT_INSTANCE_GEOMETRY );
         mSW->appendURIAttribute ( CSWC::CSW_ATTRIBUTE_URL, mUrl );
 
+		if (!mId.empty())
+			mSW->appendAttribute(CSWC::CSW_ATTRIBUTE_ID, mId);
+
+		if (!mName.empty())
+			mSW->appendAttribute(CSWC::CSW_ATTRIBUTE_NAME, mName);
+
         mBindMaterial.add();
 
         mSW->closeElement();


### PR DESCRIPTION
According to the Collada specifications 1.4.1 instance_geometry nodes are allowed to have:

    sid xs:NCName (Optional)
    name xs:NCName (Optional)
    url xs:anyURI (Required)

However when i create an instance_geometry, i only can define the writer:

COLLADASW::InstanceGeometry instGeom(mSW);

and set the URL:

void setUrl ( const URI& url )

This patch adds the missing API calls to the exporter
