### PR TITLE
Don't export color set if at least one vertex has no color from that set...

### DIFF
--- a/COLLADAMaya/include/COLLADAMayaGeometryExporter.h
+++ b/COLLADAMaya/include/COLLADAMayaGeometryExporter.h
@@ -188,10 +188,18 @@ namespace COLLADAMaya
                                    const String& meshId,
                                    const MStringArray& uvSetNames );
 
+		/**
+		 * Checks if mesh contains vertices with no vertex color from given color set.
+		 */
+		bool GeometryExporter::hasMissingVertexColor(
+			/*const */MFnMesh & fnMesh,
+			const MString & colorSetName
+			);
+
         /**
         * Export the color sets. Returns true if we should proceed to export the given color set Ids.
          */
-        void exportColorSets ( const MFnMesh& fnMesh, const String& meshId, MStringArray& colorSetNames );
+        void exportColorSets ( /*const*/ MFnMesh& fnMesh, const String& meshId, MStringArray& colorSetNames );
 
         /** Export the vertices tag with a link to the positions. */
         void exportVertices ( const String& meshId );

--- a/COLLADAMaya/include/COLLADAMayaGeometryExporter.h
+++ b/COLLADAMaya/include/COLLADAMayaGeometryExporter.h
@@ -191,7 +191,7 @@ namespace COLLADAMaya
 		/**
 		 * Checks if mesh contains vertices with no vertex color from given color set.
 		 */
-		bool GeometryExporter::hasMissingVertexColor(
+		static bool hasMissingVertexColor(
 			/*const */MFnMesh & fnMesh,
 			const MString & colorSetName
 			);


### PR DESCRIPTION
This PR removes "-1" indices for missing vertex colors.