### PR TITLE
Preserve source tree exporter option

### DIFF
--- a/COLLADABaseUtils/include/COLLADABUUtils.h
+++ b/COLLADABaseUtils/include/COLLADABUUtils.h
@@ -171,6 +171,8 @@ namespace COLLADABU
 
 		static bool createDirectoryIfNeeded( const WideString &pathString );
 		static bool createDirectoryIfNeeded( const String &pathString );
+		static bool createDirectoryRecursive( const WideString &pathString );
+		static bool createDirectoryRecursive( const String &pathString );
 		static bool directoryExists( const WideString &pathString );
 		static bool directoryExists( const String &pathString );
 

--- a/COLLADABaseUtils/src/COLLADABUUtils.cpp
+++ b/COLLADABaseUtils/src/COLLADABUUtils.cpp
@@ -278,7 +278,7 @@ namespace COLLADABU
 
 		WideString path = pathString;
 
-		if (path.back() != '/' && path.back() != '\\')
+		if (path[path.length()-1] != '/' && path[path.length()-1] != '\\')
 			path.push_back('\\');
 
 		std::list<WideString> paths;
@@ -321,7 +321,7 @@ namespace COLLADABU
 
 		String path = pathString;
 
-		if (path.back() != '/' && path.back() != '\\')
+		if (path[path.length()-1] != '/' && path[path.length()-1] != '\\')
 			path.push_back('\\');
 
 		std::list<String> paths;

--- a/COLLADAMaya/include/COLLADAMayaExportOptions.h
+++ b/COLLADAMaya/include/COLLADAMayaExportOptions.h
@@ -43,6 +43,9 @@ namespace COLLADAMaya
         /** True, if we should write relative pathes to external file references. */
         static bool mRelativePaths;
 
+		/** True, if we should keep source files tree. */
+		static bool mPreserveSourceTree;
+
         /** True, if the texture files should be copied to the destination folder. */
         static bool mCopyTextures;
         static bool mExportTriangles;
@@ -110,6 +113,7 @@ namespace COLLADAMaya
         primitive collada transforms (e.g. translate, rotate, scale)? Default: FALSE */
         static bool bakeTransforms();
         static bool relativePaths();
+		static bool preserveSourceTree();
 
         /** True, if the texture files should be copied to the destination folder. */
         static bool copyTextures();

--- a/COLLADAMaya/scripts/openColladaExporterOpts.mel
+++ b/COLLADAMaya/scripts/openColladaExporterOpts.mel
@@ -76,6 +76,13 @@ global proc int openColladaExporterOpts ( string $parent,
 							
 					checkBoxGrp
 							-l " "
+							-ncb 1
+							-v1 false
+							-l1 "Preserve source tree"
+							colladaPreserveSourceTree;
+							
+					checkBoxGrp
+							-l " "
 							-l1 "Triangulate"
 							-v1 false
 							colladaExportTriangles;
@@ -280,6 +287,11 @@ global proc int openColladaExporterOpts ( string $parent,
 					$intVal = $optionBreakDown[1];
 					checkBoxGrp -e -v2 $intVal colladaRelativePaths;
 				}
+				else if ( $optionBreakDown[0] == "preserveSourceTree" )
+				{
+					$intVal = $optionBreakDown[1];
+					checkBoxGrp -e -v1 $intVal colladaPreserveSourceTree;
+				}
 				else if ( $optionBreakDown[0] == "exportTriangles" )
 				{
 					$intVal = $optionBreakDown[1];
@@ -446,6 +458,7 @@ global proc int openColladaExporterOpts ( string $parent,
 		$currentOptions = $currentOptions + "bakeTransforms=" + `checkBoxGrp -q -v1 colladaBakeTransforms` + ";";
 		$currentOptions = $currentOptions + "relativePaths=" + `checkBoxGrp -q -v1 colladaRelativePaths` + ";";
 		$currentOptions = $currentOptions + "copyTextures=" + `checkBoxGrp -q -v2 colladaRelativePaths` + ";";
+		$currentOptions = $currentOptions + "preserveSourceTree=" + `checkBoxGrp -q -v1 colladaPreserveSourceTree` + ";";
 		$currentOptions = $currentOptions + "exportTriangles=" + `checkBoxGrp -q -v1 colladaExportTriangles` + ";";
 		$currentOptions = $currentOptions + "cgfxFileReferences=" + `checkBoxGrp -q -v1 colladaCgfxFileReferences` + ";";
  		$currentOptions = $currentOptions + "isSampling=" + `checkBoxGrp -q -v1 colladaIsSampling` + ";";

--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -232,9 +232,10 @@ namespace COLLADAMaya
         asset.getContributor().mAuthoringTool = AUTHORING_TOOL_NAME + MGlobal::mayaVersion().asChar();
 
         // comments
-        MString optstr = MString ( "\n\t\t\tColladaMaya export options: " )
-            + "\n\t\t\tbakeTransforms=" + ExportOptions::bakeTransforms() 
-            + ";relativePaths=" + ExportOptions::relativePaths() 
+		MString optstr = MString("\n\t\t\tColladaMaya export options: ")
+			+ "\n\t\t\tbakeTransforms=" + ExportOptions::bakeTransforms()
+			+ ";relativePaths=" + ExportOptions::relativePaths()
+			+ ";preserveSourceTree=" + ExportOptions::preserveSourceTree() 
             + ";copyTextures=" + ExportOptions::copyTextures() 
             + ";exportTriangles=" + ExportOptions::exportTriangles() 
             + ";exportCgfxFileReferences=" + ExportOptions::exportCgfxFileReferences() 

--- a/COLLADAMaya/src/COLLADAMayaExportOptions.cpp
+++ b/COLLADAMaya/src/COLLADAMayaExportOptions.cpp
@@ -25,6 +25,7 @@ namespace COLLADAMaya
 
     bool ExportOptions::mBakeTransforms = true;
     bool ExportOptions::mRelativePaths = true;
+	bool ExportOptions::mPreserveSourceTree = false;
     bool ExportOptions::mCopyTextures = false;
     bool ExportOptions::mExportPolygonMeshes = true;
     bool ExportOptions::mExportLights  = true;
@@ -60,6 +61,7 @@ namespace COLLADAMaya
         // Reset everything to the default value
         mBakeTransforms = false;
         mRelativePaths = true;
+		mPreserveSourceTree = false;
 
         /** True, if the texture files should be copied to the destination folder. */
         mCopyTextures = false;
@@ -121,6 +123,7 @@ namespace COLLADAMaya
                 // Process options.
                 if ( optionName == "bakeTransforms" ) mBakeTransforms = value;
                 else if ( optionName == "relativePaths" ) mRelativePaths = value;
+				else if ( optionName == "preserveSourceTree" ) mPreserveSourceTree = value;
                 else if ( optionName == "exportTriangles" ) mExportTriangles = value;
                 else if ( optionName == "cgfxFileReferences" ) mExportCgfxFileReferences = value;
                 else if ( optionName == "copyTextures" ) mCopyTextures = value;
@@ -192,6 +195,11 @@ namespace COLLADAMaya
     {
         return mRelativePaths;
     }
+
+	bool ExportOptions::preserveSourceTree()
+	{
+		return mPreserveSourceTree;
+	}
 
     bool ExportOptions::exportLights()
     {


### PR DESCRIPTION
New Maya exporter option "Preserve source tree": keeps Maya source files tree when creating texture references.