### PR TITLE
- Install relevant headers

### DIFF
--- a/COLLADAStreamWriter/CMakeLists.txt
+++ b/COLLADAStreamWriter/CMakeLists.txt
@@ -65,6 +65,7 @@ set(INST_SRC
 	include/COLLADASWSource.h
 	include/COLLADASWStreamWriter.h
 	include/COLLADASWSurfaceInitOption.h
+	include/COLLADASWTagType.h
 	include/COLLADASWTechnique.h
 	include/COLLADASWTechniqueFX.h
 	include/COLLADASWTexture.h


### PR DESCRIPTION
Install the headers for COLLADASW::TagType, since others depend on it.