### PR TITLE
Fix build on VS 2015

### DIFF
--- a/Externals/LibXML/include/win32config.h
+++ b/Externals/LibXML/include/win32config.h
@@ -95,7 +95,9 @@ static int isnan (double d) {
 
 #if defined(_MSC_VER)
 #define mkdir(p,m) _mkdir(p)
+#if _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #if _MSC_VER < 1500
 #define vsnprintf(b,c,f,a) _vsnprintf(b,c,f,a)
 #endif


### PR DESCRIPTION
Fix build on VS 2015: snprintf now exists with its proper signature and #defining it will cause an error.