### PR TITLE
Provide two argument COLLADASW::Scene constructor, similar to before …

### DIFF
--- a/COLLADAStreamWriter/include/COLLADASWScene.h
+++ b/COLLADAStreamWriter/include/COLLADASWScene.h
@@ -36,7 +36,7 @@ namespace COLLADASW
 
     public:
         /** Constructor that sets the stream the scene should be written to*/
-		Scene(StreamWriter * streamWriter, COLLADABU::URI instanceVisualSceneURI, COLLADABU::URI instancePhysicsSceneURI)
+		Scene(StreamWriter * streamWriter, COLLADABU::URI instanceVisualSceneURI, COLLADABU::URI instancePhysicsSceneURI = COLLADASW::URI())
         : ElementWriter ( streamWriter ) 
 		, mInstanceVisualSceneUrl(instanceVisualSceneURI)
 		, mInstancePhysicsSceneUrl(instancePhysicsSceneURI)


### PR DESCRIPTION
As discussed in [1] here is a pull request to reinstate a constructor to COLLADASW::Scene as it was before 6fa340dd64ca813a45ebe3db28b23f93b1ba0916. Effectively making the PhysicsSceneUrl optional. This in order for downstream applications to have a more stable api. Hope my change makes sense.

[1] https://github.com/KhronosGroup/OpenCOLLADA/issues/339