### PR TITLE
USE_STATIC_MSVC_RUNTIME build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ option(USE_STATIC "Build static libraries"  ON)
 option(USE_SHARED "Build shared libraries"  OFF)
 option(USE_LIBXML "Use LibXml2 parser"      ON)
 option(USE_EXPAT  "Use expat parser"        OFF)
+option(USE_STATIC_MSVC_RUNTIME "Use static version of the MSVC run-time library" OFF)
 
 #adding xml2
 if (USE_LIBXML)
@@ -226,6 +227,19 @@ if (USE_EXPAT)
 	message("FATAL: EXPAT support not implemented")
 	# TODO:: use externals
 endif ()
+
+if(USE_STATIC_MSVC_RUNTIME)
+	foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
+			CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+			CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+		if(${flag} MATCHES "/MD")
+			STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+		endif()
+		if(${flag} MATCHES "/MDd")
+			STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
+		endif()
+	endforeach()
+endif()
 
 #adding PCRE
 find_package(PCRE)

--- a/Externals/LibXML/CMakeLists.txt
+++ b/Externals/LibXML/CMakeLists.txt
@@ -1,6 +1,19 @@
 set(name xml)
 project(${name})
 
+if(USE_STATIC_MSVC_RUNTIME)
+	foreach(flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL
+			CMAKE_CXX_FLAGS_RELWITHDEBINFO CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+			CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+		if(${flag} MATCHES "/MD")
+			STRING(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+		endif()
+		if(${flag} MATCHES "/MDd")
+			STRING(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
+		endif()
+	endforeach()
+endif()
+
 set(libxml_include_dirs
 	${CMAKE_CURRENT_SOURCE_DIR}/include
 )


### PR DESCRIPTION
Build option to generate code using the static MSVC run-time instead of the DLL run-time (the default behavior of CMake). This is useful when building an application executable that uses OpenCOLLADA and not wanting to depend on the end-user to install the right version of Microsoft Visual C++ Redistributable for Visual Studio XXXX.