### PR TITLE
Fixed node id generation to support references

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -454,9 +454,9 @@ namespace COLLADAMaya
     {
         // Make an unique COLLADA Id from a dagPath.
         // We are free to use anything we want for Ids. For now use
-        // a honking unique name for readability - but in future we
+        // full path name for readability - but in future we
         // could just use an incrementing integer
-        return mayaNameToColladaName ( dagPath.partialPathName(), false, removeFirstNamespace );
+        return mayaNameToColladaName(dagPath.fullPathName(), false, removeFirstNamespace);
     }
 
     //---------------------------

--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -454,8 +454,8 @@ namespace COLLADAMaya
     {
         // Make an unique COLLADA Id from a dagPath.
         // We are free to use anything we want for Ids. For now use
-        // full path name for readability - but in future we
-        // could just use an incrementing integer
+        // full path name to ensure id uniqueness. DagPath partial name can not be used
+        // because it can lead to issues when referencing nodes sharing the same name.
         return mayaNameToColladaName(dagPath.fullPathName(), false, removeFirstNamespace);
     }
 


### PR DESCRIPTION
Id generation now uses dagpath full path name instead of dagpath partial name. This adds support for referencing nodes with duplicated names.