### PR TITLE
Fix/maya display error

### DIFF
--- a/COLLADAMaya/include/COLLADAMayaExportOptions.h
+++ b/COLLADAMaya/include/COLLADAMayaExportOptions.h
@@ -133,6 +133,7 @@ namespace COLLADAMaya
         /****************************/
 
 		static bool exportPhysics();
+        static void setExportPhysics(bool value);
         static bool exportConvexMeshGeometries();
         static bool exportPolygonMeshes();
         static bool exportLights();

--- a/COLLADAMaya/include/COLLADAMayaPhysXExporter.h
+++ b/COLLADAMaya/include/COLLADAMayaPhysXExporter.h
@@ -63,6 +63,10 @@ namespace COLLADAMaya
     public:
         PhysXExporter(COLLADASW::StreamWriter& streamWriter, DocumentExporter& documentExporter);
 
+        static bool CheckPhysXPluginVersion();
+        static MString GetRequiredPhysXPluginVersion();
+        static MString GetInstalledPhysXPluginVersion();
+
         bool generatePhysXXML();
         bool needsConvexHullOf(const SceneElement & element, MObject & shape);
         bool exportPhysicsLibraries();

--- a/COLLADAMaya/src/COLLADAMayaAnimationElement.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAnimationElement.cpp
@@ -83,7 +83,7 @@ namespace COLLADAMaya
 //         if ( ( ( mSampleType & kAngle ) == kAngle ) ||
 //                 ( ( mSampleType & kQualifiedAngle ) == kQualifiedAngle ) )
 //         {
-//             MGlobal::displayError ( MString ( "Unknown dimension: " ) + mSampleType );
+//             MGlobal::displayWarning ( MString ( "Unknown dimension: " ) + mSampleType );
 //             return 0;
 //         }
 

--- a/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaAnimationExporter.cpp
@@ -1704,7 +1704,7 @@ namespace COLLADAMaya
             MFnMesh meshNode ( node, &status );
             if ( status != MStatus::kSuccess ) 
             {
-                MGlobal::displayError ( "No mesh object!" );
+                MGlobal::displayWarning ( "No mesh object!" );
                 return EMPTY_STRING;
             }
             MDagPath dagPath = meshNode.dagPath ();

--- a/COLLADAMaya/src/COLLADAMayaControllerExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaControllerExporter.cpp
@@ -803,15 +803,15 @@ namespace COLLADAMaya
             MStatus status;
             MPlug plug = ShaderHelper::findPlug(MFnDependencyNode(cluster), ATTR_INPUt, &status);
             if (status != MStatus::kSuccess)
-            { MGlobal::displayError("Unable to get joint cluster input plug."); return; }
+            { MGlobal::displayWarning("Unable to get joint cluster input plug."); return; }
 
             plug = plug.elementByLogicalIndex(clusterIndex, &status);
             if (status != MStatus::kSuccess)
-            { MGlobal::displayError("Unable to get joint cluster input plug first element."); return; }
+            { MGlobal::displayWarning("Unable to get joint cluster input plug first element."); return; }
 
             plug = DagHelper::getChildPlug(plug, ATTR_INPUT_GEOMETRY, &status); // "inputGeometry"
             if (status != MStatus::kSuccess)
-            { MGlobal::displayError("Unable to get joint cluster input geometry plug."); return; }
+            { MGlobal::displayWarning("Unable to get joint cluster input geometry plug."); return; }
 
             cluster = DagHelper::getSourceNodeConnectedTo(plug);
         }

--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -236,20 +236,20 @@ namespace COLLADAMaya
                 mControllerExporter->exportControllers();
 
                 // Export PhysX to XML before exporting geometries
-                mPhysXExporter->generatePhysXXML();
+                if (ExportOptions::exportPhysics() && !mPhysXExporter->generatePhysXXML()) {
+                    // Don't try to export Physics if xml export has failed
+                    ExportOptions::setExportPhysics(false);
+                    MGlobal::displayError(MString("Error while exporting PhysX scene to XML. Physics not exported."));
+                }
 
                 // Export the geometries
                 mGeometryExporter->exportGeometries();
 
-				// Export Physics
-				mPhysicsExporter->exportAllPhysics();
-
-                // Export PhysX
-                bool physicsSceneExported = mPhysXExporter->exportPhysicsLibraries();
-				
-				// Export the physics scene
-				physicsSceneExported |= mPhysicsSceneExporter->exportPhysicsScenes();
-
+                bool physicsSceneExported = false;
+                if (ExportOptions::exportPhysics()) {
+                    // Export PhysX
+                    physicsSceneExported = mPhysXExporter->exportPhysicsLibraries();
+                }
 
 				saveParamClip();
 

--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -235,6 +235,13 @@ namespace COLLADAMaya
                 // geometry, we also have to export it).
                 mControllerExporter->exportControllers();
 
+                // Don't export Physics if required PhysX plugin is not loaded
+                if (ExportOptions::exportPhysics() && !PhysXExporter::CheckPhysXPluginVersion()) {
+                    MGlobal::displayWarning(MString("Physics not exported. Minimum PhysX plugin version: ") + PhysXExporter::GetRequiredPhysXPluginVersion());
+                    MGlobal::displayWarning(MString("Installed version: ") + PhysXExporter::GetInstalledPhysXPluginVersion());
+                    ExportOptions::setExportPhysics(false);
+                }
+
                 // Export PhysX to XML before exporting geometries
                 if (ExportOptions::exportPhysics() && !mPhysXExporter->generatePhysXXML()) {
                     // Don't try to export Physics if xml export has failed

--- a/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaDocumentExporter.cpp
@@ -246,7 +246,7 @@ namespace COLLADAMaya
                 if (ExportOptions::exportPhysics() && !mPhysXExporter->generatePhysXXML()) {
                     // Don't try to export Physics if xml export has failed
                     ExportOptions::setExportPhysics(false);
-                    MGlobal::displayError(MString("Error while exporting PhysX scene to XML. Physics not exported."));
+                    MGlobal::displayWarning(MString("Error while exporting PhysX scene to XML. Physics not exported."));
                 }
 
                 // Export the geometries

--- a/COLLADAMaya/src/COLLADAMayaEffectExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaEffectExporter.cpp
@@ -207,11 +207,11 @@ namespace COLLADAMaya
         }
 		else if (shader.hasFn(MFn::kPluginHwShaderNode) && shaderNodeTypeName == COLLADA_FX_SHADER)
         {
-            MGlobal::displayError("Export of ColladaFXShader not implemented!");
+            MGlobal::displayWarning("Export of ColladaFXShader not implemented!");
         }
 		else if (shader.hasFn(MFn::kPluginHwShaderNode) && shaderNodeTypeName == COLLADA_FX_PASSES)
         {
-            MGlobal::displayError("Export of ColladaFXPasses not implemented!");
+            MGlobal::displayWarning("Export of ColladaFXPasses not implemented!");
         }
 
 #if MAYA_API_VERSION > 700 
@@ -227,7 +227,7 @@ namespace COLLADAMaya
         // Custom hardware shaders derived from MPxHwShaderNode (the old stuff)
         else if ( shader.hasFn ( MFn::kPluginHardwareShader ) )
         {
-            MGlobal::displayError("Export HardwareShader not implemented!");
+            MGlobal::displayWarning("Export HardwareShader not implemented!");
         }
 #endif
 #if MAYA_API_VERSION >= 201500

--- a/COLLADAMaya/src/COLLADAMayaEffectTextureExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaEffectTextureExporter.cpp
@@ -351,14 +351,14 @@ namespace COLLADAMaya
                     {
 						exists = false;
                         String message = "Could not successful create directory and copy file: " + sourceUri.toNativePath();
-                        MGlobal::displayError( message.c_str() );
+                        MGlobal::displayWarning( message.c_str() );
                         std::cerr << "[ERROR] Could not copy file " << sourceUri.toNativePath() << std::endl;
                     }
 
 					if( !exists )
 					{
 						String message = "Could not successful create directory and copy file: " + sourceUri.toNativePath();
-						MGlobal::displayError( message.c_str() );
+						MGlobal::displayWarning( message.c_str() );
 						std::cerr << "[ERROR] Could not copy file " << sourceUri.toNativePath() << std::endl;
 					}
 				}
@@ -398,7 +398,7 @@ namespace COLLADAMaya
 				String message = "Not able to generate a relative path from " 
 					+ mayaSourceFileUri.getURIString() + " to " + sourceUri.getURIString() 
 					+ ". An absolute path will be written! ";
-				MGlobal::displayError ( message.c_str() );
+				MGlobal::displayWarning ( message.c_str() );
 				targetUri = sourceUri;
 			}
 			else
@@ -637,7 +637,7 @@ namespace COLLADAMaya
 					String message = "Not able to generate a relative path from " 
 						+ mayaSourceFileUri.getURIString() + " to " + sourceUri.getURIString() 
 						+ ". An absolute path will be written! ";
-					MGlobal::displayError ( message.c_str() );
+					MGlobal::displayWarning ( message.c_str() );
 					fullFileNameURI = sourceUri;
 				}
 			}
@@ -660,7 +660,7 @@ namespace COLLADAMaya
                     String message = "Not able to generate a relative path from " 
                         + targetColladaUri.getURIString() + " to " + textureUri.getURIString() 
                         + ". An absolute path will be written! ";
-                    MGlobal::displayError ( message.c_str() );
+                    MGlobal::displayWarning ( message.c_str() );
                     fullFileNameURI = textureUri;
                 }
             }
@@ -679,7 +679,7 @@ namespace COLLADAMaya
                     String message = "Not able to generate a relative path from " 
                         + targetColladaUri.getURIString() + " to " + sourceUri.getURIString() 
                         + ". An absolute path will be written! ";
-                    MGlobal::displayError ( message.c_str() );
+                    MGlobal::displayWarning ( message.c_str() );
                     fullFileNameURI = sourceUri;
                 }
             }

--- a/COLLADAMaya/src/COLLADAMayaExportOptions.cpp
+++ b/COLLADAMaya/src/COLLADAMayaExportOptions.cpp
@@ -180,6 +180,11 @@ namespace COLLADAMaya
 		return mExportPhysics;
 	}
 
+    void ExportOptions::setExportPhysics(bool value)
+    {
+        mExportPhysics = value;
+    }
+
     bool ExportOptions::exportConvexMeshGeometries()
     {
         return mExportConvexMeshGeometries;

--- a/COLLADAMaya/src/COLLADAMayaFileTranslator.cpp
+++ b/COLLADAMaya/src/COLLADAMayaFileTranslator.cpp
@@ -108,7 +108,7 @@
         if ( !status )
         {
             status.perror ( "registerFileTranslator" );
-            MGlobal::displayError ( MString ( "Unable to register OpenCOLLADA exporter: " ) + status );
+            MGlobal::displayWarning ( MString ( "Unable to register OpenCOLLADA exporter: " ) + status );
             return status;
         }
 
@@ -122,7 +122,7 @@
         if ( !status )
         {
             status.perror ( "registerFileTranslator" );
-            MGlobal::displayError ( MString ( "Unable to register OpenCOLLADA importer: " ) + status );
+            MGlobal::displayWarning ( MString ( "Unable to register OpenCOLLADA importer: " ) + status );
         }
 
         // TODO
@@ -161,7 +161,7 @@
         if ( !status )
         {
             status.perror ( "deregisterFileTranslator" );
-            MGlobal::displayError ( MString ( "Unable to unregister OpenCOLLADA exporter: " ) + status );
+            MGlobal::displayWarning ( MString ( "Unable to unregister OpenCOLLADA exporter: " ) + status );
             return status;
         }
 
@@ -170,7 +170,7 @@
         if ( !status )
         {
             status.perror ( "deregisterFileTranslator" );
-            MGlobal::displayError ( MString ( "Unable to unregister OpenCOLLADA importer: " ) + status );
+            MGlobal::displayWarning ( MString ( "Unable to unregister OpenCOLLADA importer: " ) + status );
             return status;
         }
 
@@ -292,11 +292,11 @@ namespace COLLADAMaya
         catch ( COLLADASW::StreamWriterException* swException  )
         {
             String message = "StreamWriterException: " + swException->getMessage();
-            MGlobal::displayError ( message.c_str() );
+            MGlobal::displayWarning ( message.c_str() );
         }
         catch ( ... )
         {
-            MGlobal::displayError ( "ColladaMaya has thrown an exception!" );
+            MGlobal::displayWarning ( "ColladaMaya has thrown an exception!" );
         }
 
         return status;
@@ -378,11 +378,11 @@ namespace COLLADAMaya
         }
         catch ( COLLADABU::Exception* exception  )
         {
-            MGlobal::displayError ( exception->getMessage().c_str() );
+            MGlobal::displayWarning ( exception->getMessage().c_str() );
         }
         catch ( ... )
         {
-            MGlobal::displayError ( "ColladaMaya has thrown an exception!" );
+            MGlobal::displayWarning ( "ColladaMaya has thrown an exception!" );
         }
 
         return status;

--- a/COLLADAMaya/src/COLLADAMayaGeometryExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaGeometryExporter.cpp
@@ -1406,7 +1406,7 @@ namespace COLLADAMaya
         MObject meshNode = dagPath.node();
         if ( !meshNode.hasFn ( MFn::kMesh ) ) 
         {
-            MGlobal::displayError ( "No mesh object!" );
+            MGlobal::displayWarning ( "No mesh object!" );
             return EMPTY_STRING;
         }
 
@@ -1416,7 +1416,7 @@ namespace COLLADAMaya
         MFnMesh fnMesh ( meshNode, &status );
         if ( status != MStatus::kSuccess ) 
         {
-            MGlobal::displayError ( "No mesh object!" );
+            MGlobal::displayWarning ( "No mesh object!" );
             return EMPTY_STRING;
         }
 

--- a/COLLADAMaya/src/COLLADAMayaGeometryPolygonExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaGeometryPolygonExporter.cpp
@@ -918,7 +918,7 @@ namespace COLLADAMaya
                     {
                         // Assert, if we don't have initialized the normal indices,
                         // but want to read them out here!
-                        MGlobal::displayError("No face vertex normals to proceed!");
+                        MGlobal::displayWarning("No face vertex normals to proceed!");
                         COLLADABU_ASSERT ( mHasFaceVertexNormals );
                         return;
                     }

--- a/COLLADAMaya/src/COLLADAMayaHwShaderExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaHwShaderExporter.cpp
@@ -154,7 +154,7 @@ namespace COLLADAMaya
         const cgfxRCPtr<const cgfxEffect>& cgEffect = shaderNodeCgfx->effect();
         if( cgEffect.isNull() )
         {
-            MGlobal::displayError ("cgEffect is null.");
+            MGlobal::displayWarning ("cgEffect is null.");
             return;
         }
 
@@ -894,7 +894,7 @@ namespace COLLADAMaya
         }
         if ( cgTextureParam == 0 )
         {
-            MGlobal::displayError ( "No surface for the current sampler! Data not valid!" );
+            MGlobal::displayWarning ( "No surface for the current sampler! Data not valid!" );
             return;
         }
 

--- a/COLLADAMaya/src/COLLADAMayaMaterialExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaMaterialExporter.cpp
@@ -716,7 +716,7 @@ namespace COLLADAMaya
         const cgfxRCPtr<const cgfxEffect>& cgEffect = shaderNodeCgfx->effect();
         if( cgEffect.isNull() )
         {
-            MGlobal::displayError ( "cgEffect is null." );
+            MGlobal::displayWarning ( "cgEffect is null." );
             return;
         }
 

--- a/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
@@ -646,13 +646,13 @@ namespace COLLADAMaya
     {
         // Shape node
         MFnDagNode shapeNode(shape);
-        MString shapeName = shapeNode.name();
+        MString shapeName = shapeNode.fullPathName();
 
         // Rigid body target
         MObject target;
         getRigidBodyTarget(rigidBody, target);
         MFnDagNode targetNode(target);
-        MString targetName = targetNode.name();
+        MString targetName = targetNode.fullPathName();
 
         return mPhysXDoc->findShape(targetName.asChar(), shapeName.asChar());
     }
@@ -662,7 +662,7 @@ namespace COLLADAMaya
         MObject target;
         getRigidBodyTarget(rigidBody, target);
         MFnDagNode targetNode(target);
-        MString targetName = targetNode.name();
+        MString targetName = targetNode.fullPathName();
         return findPxRigidStatic(targetName.asChar());
     }
 
@@ -676,14 +676,14 @@ namespace COLLADAMaya
         MObject target;
         getRigidBodyTarget(rigidBody, target);
         MFnDagNode targetNode(target);
-        MString targetName = targetNode.name();
+        MString targetName = targetNode.fullPathName();
         return mPhysXDoc->findRigidDynamic(targetName.asChar());
     }
 
     PhysXXML::PxD6Joint* PhysXExporter::findPxD6Joint(const MObject& rigidConstraint)
     {
         MFnDagNode constraintNode(rigidConstraint);
-        MString constraintName = constraintNode.name();
+        MString constraintName = constraintNode.fullPathName();
         return mPhysXDoc->findD6Joint(constraintName.asChar());
     }
 

--- a/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
@@ -3368,7 +3368,7 @@ namespace COLLADAMaya
         // Export to .xml format first using PhysX plugin exporter.
         // Produced file contains information not accessible with Maya API.
         if (!mPhysXDoc) {
-            MGlobal::displayError("Can't generate PhysX XML data. PhysX will not be exported.");
+            MGlobal::displayWarning("Can't generate PhysX XML data. PhysX will not be exported.");
             return false;
         }
 

--- a/COLLADAMaya/src/COLLADAMayaPhysXXML.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXXML.cpp
@@ -2182,7 +2182,7 @@ namespace COLLADAMaya
                 for (size_t j = 0; j < physX30Collection.rigidDynamics.size(); ++j) {
                     if (i != j &&
                         physX30Collection.rigidDynamics[i].name.name == physX30Collection.rigidDynamics[j].name.name) {
-                        MGlobal::displayError((String("Duplicated dynamic rigid body name: ") + physX30Collection.rigidDynamics[i].name.name).c_str());
+                        MGlobal::displayWarning((String("Duplicated dynamic rigid body name: ") + physX30Collection.rigidDynamics[i].name.name).c_str());
                         return false;
                     }
                 }
@@ -2193,7 +2193,7 @@ namespace COLLADAMaya
                         if (si !=  sj &&
                             physX30Collection.rigidDynamics[i].shapes.shapes[si].name.name ==
                             physX30Collection.rigidDynamics[i].shapes.shapes[sj].name.name) {
-                            MGlobal::displayError((String("Duplicated shape name: ") + physX30Collection.rigidDynamics[i].shapes.shapes[si].name.name).c_str());
+                            MGlobal::displayWarning((String("Duplicated shape name: ") + physX30Collection.rigidDynamics[i].shapes.shapes[si].name.name).c_str());
                             return false;
                         }
                     }
@@ -2204,7 +2204,7 @@ namespace COLLADAMaya
                 for (size_t j = 0; j < physX30Collection.rigidStatics.size(); ++j) {
                     if (i != j &&
                         physX30Collection.rigidStatics[i].name.name == physX30Collection.rigidStatics[j].name.name) {
-                        MGlobal::displayError((String("Duplicated static rigid body name: ") + physX30Collection.rigidStatics[i].name.name).c_str());
+                        MGlobal::displayWarning((String("Duplicated static rigid body name: ") + physX30Collection.rigidStatics[i].name.name).c_str());
                         return false;
                     }
                 }
@@ -2215,7 +2215,7 @@ namespace COLLADAMaya
                         if (si !=  sj &&
                             physX30Collection.rigidStatics[i].shapes.shapes[si].name.name ==
                             physX30Collection.rigidStatics[i].shapes.shapes[sj].name.name) {
-                            MGlobal::displayError((String("Duplicated shape name: ") + physX30Collection.rigidStatics[i].shapes.shapes[si].name.name).c_str());
+                            MGlobal::displayWarning((String("Duplicated shape name: ") + physX30Collection.rigidStatics[i].shapes.shapes[si].name.name).c_str());
                             return false;
                         }
                     }
@@ -2226,7 +2226,7 @@ namespace COLLADAMaya
                 for (size_t j = 0; j < physX30Collection.D6Joints.size(); ++j) {
                     if (i != j &&
                         physX30Collection.D6Joints[i].name.name == physX30Collection.D6Joints[j].name.name) {
-                        MGlobal::displayError((String("Duplicated constraint name: ") + physX30Collection.D6Joints[i].name.name).c_str());
+                        MGlobal::displayWarning((String("Duplicated constraint name: ") + physX30Collection.D6Joints[i].name.name).c_str());
                         return false;
                     }
                 }

--- a/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaVisualSceneExporter.cpp
@@ -234,7 +234,7 @@ namespace COLLADAMaya
         case MFn::kPoleVectorConstraint:
         case MFn::kPointConstraint:
         case MFn::kNormalConstraint:
-            MGlobal::displayError ( "Export of constraints not supported: " 
+            MGlobal::displayWarning ( "Export of constraints not supported: " 
                 + MString ( sceneElement->getNodeName ().c_str () ) );
             break;
 
@@ -250,7 +250,7 @@ namespace COLLADAMaya
         case MFn::kIkHandle:
             if ( ExportOptions::exportJointsAndSkin() )
             {
-                MGlobal::displayError ( "Export of ik handles not supported: " 
+                MGlobal::displayWarning ( "Export of ik handles not supported: " 
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
@@ -261,26 +261,26 @@ namespace COLLADAMaya
         case MFn::kRigid:
             //if ( ExportOptions::exportPhysics() )
             {
-                MGlobal::displayError ( "Export of physics not supported: "
+                MGlobal::displayWarning ( "Export of physics not supported: "
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
 
         case MFn::kNurbsCurve:
             {
-                MGlobal::displayError ( "Export of spline not supported: " 
+                MGlobal::displayWarning ( "Export of spline not supported: " 
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
         case MFn::kNurbsSurface:
             {
-                MGlobal::displayError ( "Export of nurbs not supported: "
+                MGlobal::displayWarning ( "Export of nurbs not supported: "
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
         case MFn::kEmitter:
             {
-                MGlobal::displayError ( "Export of emitters not supported: "
+                MGlobal::displayWarning ( "Export of emitters not supported: "
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
@@ -295,7 +295,7 @@ namespace COLLADAMaya
         case MFn::kVortex:
         case MFn::kVolumeAxis:
             {
-                MGlobal::displayError ( "Could not export. Unknown node type: " 
+                MGlobal::displayWarning ( "Could not export. Unknown node type: " 
                     + MString ( sceneElement->getNodeName ().c_str () ) );
             }
             break;
@@ -397,7 +397,7 @@ namespace COLLADAMaya
             {
                 MString pathName = dagPath.fullPathName();
                 MString message = "Could not initialize the transform object of the path " + pathName;
-                MGlobal::displayError( message );
+                MGlobal::displayWarning( message );
                 return false;
             }
         }

--- a/dae2ma/src/DAE2MADocumentImporter.cpp
+++ b/dae2ma/src/DAE2MADocumentImporter.cpp
@@ -265,7 +265,7 @@ namespace DAE2MA
         if ( std::ifstream ( mayaAsciiFileName.c_str () ) )
         {
             // TODO Open a dialog and ask the user to save the file under an other name.
-            //MGlobal::displayError ( "File already exists!\n" );
+            //MGlobal::displayWarning ( "File already exists!\n" );
             //MGlobal::doErrorLogEntry ( "File already exists!\n" );
             std::cerr << "Overwrite existing file!" << std::endl;
         }


### PR DESCRIPTION
Please merge https://github.com/KhronosGroup/OpenCOLLADA/pull/396 before.

This is a workaround for a bug in Maya. When an exporter is called from a Python script and calls MGlobal::displayError() function then Maya crashes after export. Using MGlobal::displayWarning() instead fixes the issue.

This PR should be reverted once Autodesk will have fixed the issue.