### PR TITLE
[Security Bug] Fix Insecure Runpaths in /usr/bin/OpenCOLLADAValidator

### DIFF
--- a/COLLADAValidator/CMakeLists.txt
+++ b/COLLADAValidator/CMakeLists.txt
@@ -33,6 +33,8 @@ include_directories(
 	${libSaxFrameworkLoader_include_dirs}
 	${libGeneratedSaxParser_include_dirs}
 )
+
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 link_directories(${LIBRARY_OUTPUT_PATH})
 
 add_executable(${name} ${SRC})


### PR DESCRIPTION
The runpath includes the build directory, which is build/lib.
This needs to be removed from the runpath or an attacker can take
advantage of this by injecting arbitrary code.

Closes Bug #449