### PR TITLE
Fix light decay type

### DIFF
--- a/COLLADAMax/src/COLLADAMaxLightExporter.cpp
+++ b/COLLADAMax/src/COLLADAMaxLightExporter.cpp
@@ -291,7 +291,8 @@ namespace COLLADAMax
 
 		if (isSpot || isPoint)
 		{
-			int decayFunction = parameters->GetInt(isPoint ? MaxLight::PB_OMNIDECAY : MaxLight::PB_DECAY, mDocumentExporter->getOptions().getAnimationStart());
+			GenLight* light = (GenLight*)(lightObject);
+			int decayFunction = (int)light->GetDecayType();
 			switch (decayFunction)
 			{
 			case 1:


### PR DESCRIPTION
The PB_DECAY and PB_OMNIDECAY parameters refer to the decay start distance from the light, not the decay type, and return a float; if this ever worked, it must've been by accident.