### PR TITLE
Export rigid_body mass only if overriding shapes mass.

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
@@ -1853,16 +1853,24 @@ namespace COLLADAMaya
 
 		void exportMass(const MObject & rigidBody, const PhysXXML::PxRigidBody & pxRigidBody)
         {
-			if (pxRigidBody.getType() == PhysXXML::PxRigidBody::Dynamic)
+			int dummy = 0;
+			MString overrideMassOrDensityStr;
+			DagHelper::getPlugValue(rigidBody, ATTR_OVERRIDE_MASS_OR_DENSITY, dummy, overrideMassOrDensityStr);
+			bool overrideMassOrDensity = overrideMassOrDensityStr != OVERRIDE_MASS_OR_DENSITY_DISABLED;
+
+			if (overrideMassOrDensity)
 			{
-				const PhysXXML::PxRigidDynamic & rigidDynamic = static_cast<const PhysXXML::PxRigidDynamic&>(pxRigidBody);
-				// PhysX mass is in grams. COLLADA uses kilograms.
-				Mass e(getPhysXExporter(), rigidDynamic.mass.mass / 1000.0);
-			}
-			else
-			{
-				double mass = getPhysXExporter().GetRigidBodyMass(rigidBody);
-				Mass e(getPhysXExporter(), mass);
+				if (pxRigidBody.getType() == PhysXXML::PxRigidBody::Dynamic)
+				{
+					const PhysXXML::PxRigidDynamic & rigidDynamic = static_cast<const PhysXXML::PxRigidDynamic&>(pxRigidBody);
+					// PhysX mass is in grams. COLLADA uses kilograms.
+					Mass e(getPhysXExporter(), rigidDynamic.mass.mass / 1000.0);
+				}
+				else
+				{
+					double mass = getPhysXExporter().GetRigidBodyMass(rigidBody);
+					Mass e(getPhysXExporter(), mass);
+				}
 			}
         }
 

--- a/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
@@ -4838,13 +4838,6 @@ namespace COLLADAMaya
         // Backup export options
         AutoRestorePhysXExportOptions autoRestorePhysXExportOptions;
 
-        // PhysX internal data is in centimeters and we need to export to UI unit.
-        MDistance unitDistance = MDistance(1.0, MDistance::uiUnit());
-        double asCentimeters = unitDistance.asCentimeters();
-        double centimetersToUIUnit = 1.0 / asCentimeters;
-        MString centimetersToUIUnitStr = "";
-        centimetersToUIUnitStr += centimetersToUIUnit;
-
         // Set export options
         status = MGlobal::executeCommand("optionVar -iv \"apexClothingExport_APBs\" 2");
         if (!status) return false;
@@ -4862,11 +4855,11 @@ namespace COLLADAMaya
         if (!status) return false;
         status = MGlobal::executeCommand("optionVar -iv \"PhysXExport_exportPhysX\" 1");
         if (!status) return false;
-        status = MGlobal::executeCommand("optionVar -sv \"PhysXExport_outputUnit\" \"meter\""); // Has no effect
+        status = MGlobal::executeCommand("optionVar -sv \"PhysXExport_outputUnit\" \"meter\"");
         if (!status) return false;
         status = MGlobal::executeCommand("optionVar -iv \"PhysXExport_customScaling\" true");
         if (!status) return false;
-        status = MGlobal::executeCommand("optionVar -fv \"PhysXExport_outputScale\" " + centimetersToUIUnitStr);
+        status = MGlobal::executeCommand("optionVar -fv \"PhysXExport_outputScale\" 1.0");
         if (!status) return false;
 
         String filePath = mDocumentExporter.getFilename();


### PR DESCRIPTION
This adds support for "Override mass or density" option in PhysX plugin for Maya. If rigid body overrides mass or density then its mass is exported and importers should ignore shapes mass or density. If rigid body does not override mass or density then its mass is not exported and importers must calculate rigid body mass from shapes masses.
