### PR TITLE
Export PhysX poses as extra.

### DIFF
--- a/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
+++ b/COLLADAMaya/src/COLLADAMayaPhysXExporter.cpp
@@ -1005,7 +1005,7 @@ namespace COLLADAMaya
     {
     public:
         LocalPose(PhysXExporter& exporter, const MQuaternion& rotation, const MVector& translation)
-            : Element(exporter, LOCAL_POSE)
+            : Element(exporter, CSWC::CSW_ELEMENT_LOCAL_POSE)
         {
             double localPose[] = { rotation.x, rotation.y, rotation.z, rotation.w, translation.x, translation.y, translation.z };
             getStreamWriter().appendValues(localPose, sizeof(localPose) / sizeof(localPose[0]));
@@ -1114,6 +1114,7 @@ namespace COLLADAMaya
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XMLNS, PhysXExporter::GetXMLNS());
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XSI_SCHEMALOCATION, PhysXExporter::GetXSISchemaLocation());
 
+			exportLocalPose(shape);
 			exportSimulationFilterData(shape);
 			exportQueryFilterData(shape);
 			exportContactOffset(shape);
@@ -1124,16 +1125,16 @@ namespace COLLADAMaya
 
 		static bool HasDefaultValues(const PhysXXML::PxShape & shape)
 		{
-			return
-				SimulationFilterData::AreDefaultValues(shape.simulationFilterData.filter0, shape.simulationFilterData.filter1, shape.simulationFilterData.filter2, shape.simulationFilterData.filter3) &&
-				QueryFilterData::AreDefaultValues(shape.queryFilterData.filter0, shape.queryFilterData.filter1, shape.queryFilterData.filter2, shape.queryFilterData.filter3) &&
-				shape.contactOffset.contactOffset == ContactOffset::DefaultValue() &&
-				shape.restOffset.restOffset == RestOffset::DefaultValue() &&
-				shape.flags.flags == ShapeFlags::DefaultValue() &&
-				shape.name.name == DebugName::DefaultValue();
+			// Always export local pose
+			return false;
 		}
 
 	private:
+		void exportLocalPose(const PhysXXML::PxShape & shape)
+		{
+			LocalPose e(getPhysXExporter(), shape.localPose.rotation, shape.localPose.translation);
+		}
+
 		void exportSimulationFilterData(const PhysXXML::PxShape & shape)
 		{
 			if (!SimulationFilterData::AreDefaultValues(
@@ -2399,6 +2400,17 @@ namespace COLLADAMaya
 		}
 	};
 
+	class GlobalPose : public Element
+	{
+	public:
+		GlobalPose(PhysXExporter& exporter, const MQuaternion & rotation, const MVector & translation)
+			: Element(exporter, CSWC::CSW_ELEMENT_GLOBAL_POSE)
+		{
+			double pose [] = { rotation.x, rotation.y, rotation.z, rotation.w, translation.x, translation.y, translation.z };
+			getStreamWriter().appendValues(pose, sizeof(pose) / sizeof(pose[0]));
+		}
+	};
+
 	class PxRigidBody : public Element
 	{
 	public:
@@ -2408,6 +2420,7 @@ namespace COLLADAMaya
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XMLNS, PhysXExporter::GetXMLNS());
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XSI_SCHEMALOCATION, PhysXExporter::GetXSISchemaLocation());
 
+			exportGlobalPose(rb);
 			exportActorFlags(rb);
 			exportDominanceGroup(rb);
 			exportOwnerClient(rb);
@@ -2431,33 +2444,16 @@ namespace COLLADAMaya
 
 		static bool HasDefaultValues(const PhysXXML::PxRigidBody & rb)
 		{
-			bool hasCommonDefaultValues =
-				rb.actorFlags.actorFlags == ActorFlags::DefaultValue() &&
-				rb.dominanceGroup.dominanceGroup == DominanceGroup::DefaultValue() &&
-				rb.ownerClient.ownerClient == OwnerClient::DefaultValue();
-
-			if (rb.getType() == PhysXXML::PxRigidBody::Dynamic)
-			{
-				const PhysXXML::PxRigidDynamic & rd = static_cast<const PhysXXML::PxRigidDynamic&>(rb);
-				return hasCommonDefaultValues &&
-					rd.rigidBodyFlags.rigidBodyFlags == RigidBodyFlags::DefaultValue() &&
-					rd.minCCDAdvanceCoefficient.minCCDAdvanceCoefficient == MinCCDAdvanceCoefficient::DefaultValue() &&
-					rd.maxDepenetrationVelocity.maxDepenetrationVelocity == MaxDepenetrationVelocity::DefaultValue() &&
-					rd.linearDamping.linearDamping == LinearDamping::DefaultValue() &&
-					rd.angularDamping.angularDamping == AngularDamping::DefaultValue() &&
-					rd.maxAngularVelocity.maxAngularVelocity == MaxAngularVelocity::DefaultValue() &&
-					rd.sleepThreshold.sleepThreshold == SleepThreshold::DefaultValue() &&
-					rd.stabilizationThreshold.stabilizationThreshold == StabilizationThreshold::DefaultValue() &&
-					rd.wakeCounter.wakeCounter == WakeCounter::DefaultValue() &&
-					rd.solverIterationCounts.minPositionIters.minPositionIters == MinPositionIters::DefaultValue() &&
-					rd.solverIterationCounts.minVelocityIters.minVelocityIters == MinVelocityIters::DefaultValue() &&
-					rd.contactReportThreshold.contactReportThreshold == ContactReportThreshold::DefaultValue();
-			}
-
-			return hasCommonDefaultValues;
+			// Always export global pose
+			return false;
 		}
 
 	private:
+		void exportGlobalPose(const PhysXXML::PxRigidBody & pxRigidBody)
+		{
+			GlobalPose e(getPhysXExporter(), pxRigidBody.globalPose.rotation, pxRigidBody.globalPose.translation);
+		}
+
 		void exportActorFlags(const PhysXXML::PxRigidBody & pxRigidBody)
 		{
 			if (pxRigidBody.actorFlags.actorFlags != ActorFlags::DefaultValue())
@@ -3671,6 +3667,28 @@ namespace COLLADAMaya
 		}
 	};
 
+	class LocalPose0 : public Element
+	{
+	public:
+		LocalPose0(PhysXExporter& exporter, const MQuaternion& rotation, const MVector& translation)
+			: Element(exporter, CSWC::CSW_ELEMENT_LOCAL_POSE_0)
+		{
+			double localPose[] = { rotation.x, rotation.y, rotation.z, rotation.w, translation.x, translation.y, translation.z };
+			getStreamWriter().appendValues(localPose, sizeof(localPose) / sizeof(localPose[0]));
+		}
+	};
+
+	class LocalPose1 : public Element
+	{
+	public:
+		LocalPose1(PhysXExporter& exporter, const MQuaternion& rotation, const MVector& translation)
+			: Element(exporter, CSWC::CSW_ELEMENT_LOCAL_POSE_1)
+		{
+			double localPose[] = { rotation.x, rotation.y, rotation.z, rotation.w, translation.x, translation.y, translation.z };
+			getStreamWriter().appendValues(localPose, sizeof(localPose) / sizeof(localPose[0]));
+		}
+	};
+
 	class PxD6Joint : public Element
 	{
 	public:
@@ -3680,6 +3698,8 @@ namespace COLLADAMaya
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XMLNS, PhysXExporter::GetXMLNS());
 			getStreamWriter().appendAttribute(CSWC::CSW_ATTRIBUTE_XSI_SCHEMALOCATION, PhysXExporter::GetXSISchemaLocation());
 
+			exportLocalPose0(joint);
+			exportLocalPose1(joint);
 			exportBreakForce(joint);
 			exportBreakTorque(joint);
 			exportConstraintFlags(joint);
@@ -3696,22 +3716,21 @@ namespace COLLADAMaya
 
 		static bool HasDefaultValues(const PhysXXML::PxD6Joint & joint)
 		{
-			return
-				joint.breakForce.force.force == BreakForce::DefaultValue() &&
-				joint.breakForce.torque.torque == BreakTorque::DefaultValue() &&
-				joint.constraintFlags.flags == ConstraintFlags::DefaultValue() &&
-				joint.invMassScale0.invMassScale0 == InvMassScale0::DefaultValue() &&
-				joint.invInertiaScale0.invInertiaScale0 == InvInertiaScale0::DefaultValue() &&
-				joint.invMassScale1.invMassScale1 == InvMassScale1::DefaultValue() &&
-				joint.invInertiaScale1.invInertiaScale1 == InvInertiaScale1::DefaultValue() &&
-				joint.projectionLinearTolerance.projectionLinearTolerance == ProjectionLinearTolerance::DefaultValue() &&
-				joint.projectionAngularTolerance.projectionAngularTolerance == ProjectionAngularTolerance::DefaultValue() &&
-				LimitsExtra::HasDefaultValues(joint) &&
-				SpringExtra::HasDefaultValues(joint) &&
-				Drive::HasDefaultValues(joint);
+			// Always export local pose 0 and 1
+			return false;
 		}
 
 	private:
+		void exportLocalPose0(const PhysXXML::PxD6Joint & joint)
+		{
+			LocalPose0 e(getPhysXExporter(), joint.localPose.eActor0.rotation, joint.localPose.eActor0.translation);
+		}
+
+		void exportLocalPose1(const PhysXXML::PxD6Joint & joint)
+		{
+			LocalPose1 e(getPhysXExporter(), joint.localPose.eActor1.rotation, joint.localPose.eActor1.translation);
+		}
+
 		void exportBreakForce(const PhysXXML::PxD6Joint & joint)
 		{
 			if (joint.breakForce.force.force != BreakForce::DefaultValue())

--- a/COLLADAStreamWriter/include/COLLADASWConstants.h
+++ b/COLLADAStreamWriter/include/COLLADASWConstants.h
@@ -159,6 +159,10 @@ namespace COLLADASW
 		static const String CSW_ELEMENT_REST_OFFSET;
 		static const String CSW_ELEMENT_SHAPE_FLAGS;
 		static const String CSW_ELEMENT_ACTOR_FLAGS;
+		static const String CSW_ELEMENT_LOCAL_POSE;
+		static const String CSW_ELEMENT_LOCAL_POSE_0;
+		static const String CSW_ELEMENT_LOCAL_POSE_1;
+		static const String CSW_ELEMENT_GLOBAL_POSE;
 		static const String CSW_ELEMENT_DOMINANCE_GROUP;
 		static const String CSW_ELEMENT_OWNER_CLIENT;
 		static const String CSW_ELEMENT_RIGID_BODY_FLAGS;

--- a/COLLADAStreamWriter/src/COLLADASWConstants.cpp
+++ b/COLLADAStreamWriter/src/COLLADASWConstants.cpp
@@ -148,6 +148,10 @@ namespace COLLADASW
 	const String CSWC::CSW_ELEMENT_REST_OFFSET = "rest_offset";
 	const String CSWC::CSW_ELEMENT_SHAPE_FLAGS = "shape_flags";
 	const String CSWC::CSW_ELEMENT_ACTOR_FLAGS = "actor_flags";
+	const String CSWC::CSW_ELEMENT_LOCAL_POSE = "local_pose";
+	const String CSWC::CSW_ELEMENT_LOCAL_POSE_0 = "local_pose0";
+	const String CSWC::CSW_ELEMENT_LOCAL_POSE_1 = "local_pose1";
+	const String CSWC::CSW_ELEMENT_GLOBAL_POSE = "global_pose";
 	const String CSWC::CSW_ELEMENT_DOMINANCE_GROUP = "dominance_group";
 	const String CSWC::CSW_ELEMENT_OWNER_CLIENT = "owner_client";
 	const String CSWC::CSW_ELEMENT_RIGID_BODY_FLAGS = "rigid_body_flags";


### PR DESCRIPTION
COLLADA does not define transform for a rigid_body and supposes rigid_body's transform = target node's transform. In Maya, a rigid body can have a different transform than its targeted node. This PR adds required information to get the actual transforms used by PhysX SDK in Maya.

Applications not aware of this extension can still use the COLLADA document and simulated scene will be visually the same although transforms are internally different.

Extension specifications and schema have been updated accordingly.