### PR TITLE
Fixed document's root modification.

### DIFF
--- a/DAEValidator/include/XmlDoc.h
+++ b/DAEValidator/include/XmlDoc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "XmlNode.h"
 #include "XmlNodeSet.h"
 #include <libxml/parser.h>
 #include "no_warning_map"
@@ -29,7 +30,26 @@ namespace opencollada
 		operator bool() const;
 		void reset();
 		XmlNode root() const;
-		XmlNode setRoot(const XmlNode & node) const;
+
+		class TempRootMod
+		{
+		public:
+			TempRootMod(const XmlNode & old_root);
+			TempRootMod(TempRootMod && other);
+			~TempRootMod();
+
+		private:
+			TempRootMod(const TempRootMod&) = delete;
+			const TempRootMod & operator = (const TempRootMod&) = delete;
+
+		private:
+			XmlNode mOldDocChildren;
+			XmlNode mOldDocLast;
+		};
+
+		// Temporarily changes document's root node.
+		// Original root is restored when TempRootMod object is destroyed.
+		TempRootMod setTempRoot(const XmlNode & node) const;
 
 	private:
 		XmlDoc(const XmlDoc&) = delete;

--- a/DAEValidator/src/DaeValidator.cpp
+++ b/DAEValidator/src/DaeValidator.cpp
@@ -279,9 +279,8 @@ namespace opencollada
 			const auto & nodes = dae.root().selectNodes(xpath.str());
 			for (auto node : nodes)
 			{
-				auto old = dae.setRoot(node);
+				auto autoRestoreRoot = dae.setTempRoot(node);
 				result |= ValidateAgainstSchema(dae, schema.second);
-				dae.setRoot(old);
 			}
 		}
 
@@ -343,7 +342,7 @@ namespace opencollada
 		const auto & parents = dae.root().selectNodes("//*[@sid]/..");
 		for (auto parent : parents)
 		{
-			const auto & children = parent.selectNodes("/*[@sid]");
+			const auto & children = parent.selectNodes("*[@sid]");
 			map<string, size_t> sids;
 			for (auto child : children)
 			{

--- a/DAEValidator/src/XmlNode.cpp
+++ b/DAEValidator/src/XmlNode.cpp
@@ -78,29 +78,6 @@ namespace opencollada
 		return XmlNamespace(mNode->ns);
 	}
 
-	class ScopedSetDocRoot
-	{
-	public:
-		ScopedSetDocRoot(const XmlNode & node)
-			: mDoc(node.doc())
-			, mRoot(mDoc.root())
-		{
-			mDoc.setRoot(node);
-		}
-
-		~ScopedSetDocRoot()
-		{
-			mDoc.setRoot(mRoot);
-		}
-
-	private:
-		const ScopedSetDocRoot & operator = (const ScopedSetDocRoot &) = delete;
-
-	private:
-		XmlDoc & mDoc;
-		XmlNode mRoot;
-	};
-
 	const XmlNodeSet & XmlNode::selectNodes(const string & xpath) const
 	{
 		auto & xpathCache = XmlDoc::GetXmlDoc(mNode->doc).mXPathCache;
@@ -108,12 +85,12 @@ namespace opencollada
 		if (cache != xpathCache.end())
 			return cache->second;
 
-		ScopedSetDocRoot ssdr(*this);
-
 		if (xmlXPathContextPtr context = xmlXPathNewContext(mNode->doc))
 		{
 			xmlXPathRegisterNs(context, BAD_CAST "collada", BAD_CAST "http://www.collada.org/2005/11/COLLADASchema");
 			xmlXPathRegisterNs(context, BAD_CAST "xsi", BAD_CAST "http://www.w3.org/2001/XMLSchema-instance");
+
+			context->node = mNode;
 
 			XmlNodeSet result(xmlXPathEvalExpression(BAD_CAST xpath.c_str(), context));
 			xmlXPathFreeContext(context);


### PR DESCRIPTION
xmlDocSetRootElement() unlinks new root element from parent tree leading to missing tree branches after restoring old root.