### PR TITLE
gracefull parser abort when error detected during import

### DIFF
--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLMeshLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLMeshLoader.h
@@ -363,13 +363,13 @@ namespace COLLADASaxFWL
 
 
 		/** Sets the offsets for the different semantics (positions normals etc)*/
-		void initializeOffsets();
-        void initializeTexCoordsOffset ();
-        void initializeColorsOffset ();
+        bool initializeOffsets();
+        bool initializeTexCoordsOffset ();
+        bool initializeColorsOffset ();
         void initializeNormalsOffset ();
         void initializeTangentsOffset ();
         void initializeBinormalsOffset ();
-        void initializePositionsOffset ();
+        bool initializePositionsOffset ();
 
 		/** Writes all the indices in data into the indices array of the current mesh primitive.*/
 		bool writePrimitiveIndices ( const unsigned long long* data, size_t length );

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
@@ -707,8 +707,9 @@ namespace COLLADASaxFWL
 
 
 	//------------------------------
-	void MeshLoader::initializeOffsets()
+	bool MeshLoader::initializeOffsets()
 	{
+        bool has_errors = false;
         // Reset the members
         mCurrentOffset = 0;
         mPositionsOffset = 0;
@@ -727,37 +728,44 @@ namespace COLLADASaxFWL
 		mCurrentMaxOffset = (size_t)mMeshPrimitiveInputs.getInputArrayMaxOffset ();
 
 		// The offset values of the input elements.
-        initializePositionsOffset();
+        has_errors |= initializePositionsOffset();
         initializeNormalsOffset();
-        initializeColorsOffset();
-        initializeTexCoordsOffset();
+        has_errors |= initializeColorsOffset();
+        has_errors |= initializeTexCoordsOffset();
         initializeTangentsOffset();
         initializeBinormalsOffset();
+        return has_errors;
 	}
 
     //------------------------------
-    void MeshLoader::initializePositionsOffset ()
+    bool MeshLoader::initializePositionsOffset ()
     {
+        bool has_errors = false;
         const InputShared* positionInput = mMeshPrimitiveInputs.getPositionInput ();
-		COLLADABU_ASSERT ( positionInput != 0 );
-        if ( positionInput == 0 )
-            handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "No positions, can't import!", IError::SEVERITY_CRITICAL );
+        COLLADABU_ASSERT ( positionInput != 0 );
+        if (positionInput == 0) {
+            has_errors |= handleFWLError(SaxFWLError::ERROR_DATA_NOT_VALID, "No positions, can't import!", IError::SEVERITY_CRITICAL);
+        }
+        else {
+            // Get the offset value, the initial index values and alloc the memory.
+            mPositionsOffset = positionInput->getOffset();
+        }
 
-        // Get the offset value, the initial index values and alloc the memory.
-        mPositionsOffset = positionInput->getOffset ();
         COLLADABU::URI inputUrl = positionInput->getSource ();
         String sourceId = inputUrl.getFragment ();
         const SourceBase* sourceBase = getSourceById ( sourceId );
         COLLADABU_ASSERT ( sourceBase != 0 );
         if ( sourceBase == 0 )
-            handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "Positions sourceBase is null.", IError::SEVERITY_CRITICAL );
+            has_errors |= handleFWLError(SaxFWLError::ERROR_DATA_NOT_VALID, "Positions sourceBase is null.", IError::SEVERITY_CRITICAL);
+        else {
+            // only stride 3 makes sense for normals
+            unsigned long long stride = sourceBase->getStride();
+            if (stride != 3)
+                has_errors |= handleFWLError(SaxFWLError::ERROR_DATA_NOT_VALID, "Positios stride is not three.", IError::SEVERITY_CRITICAL);
 
-        // only stride 3 makes sense for normals
-        unsigned long long stride = sourceBase->getStride();
-        if ( stride != 3 )
-            handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "Positios stride is not three.", IError::SEVERITY_CRITICAL );
-
-        mPositionsIndexOffset = (unsigned int)sourceBase->getInitialIndex();
+            mPositionsIndexOffset = (unsigned int)sourceBase->getInitialIndex();
+        }
+        return has_errors;
     }
 
     //------------------------------
@@ -876,7 +884,7 @@ namespace COLLADASaxFWL
     }
 
     //------------------------------
-    void MeshLoader::initializeColorsOffset ()
+    bool MeshLoader::initializeColorsOffset ()
     {
         // Check for using colors
         const InputSharedArray& inputArray = mMeshPrimitiveInputs.getInputArray ();
@@ -892,8 +900,7 @@ namespace COLLADASaxFWL
                 SourceBase* sourceBase = getSourceById ( sourceId );
                 if ( sourceBase == 0 ) 
                 {
-                    handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "SourceBase of tex coords with semantic TEXCOORD not valid!" );
-                    return;
+                    return handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "SourceBase of tex coords with semantic TEXCOORD not valid!" );
                 }
 
                 // only stride 1, 2, 3 or 4 makes sense for uv coords
@@ -913,11 +920,13 @@ namespace COLLADASaxFWL
                 mColorList.push_back ( color );
             }
         }
+		return false;
     }
 
     //------------------------------
-    void MeshLoader::initializeTexCoordsOffset ()
+    bool MeshLoader::initializeTexCoordsOffset ()
     {
+		bool has_errors = false;
         // Check for using tex coordinates 
         const InputSharedArray& inputArray = mMeshPrimitiveInputs.getInputArray ();
         size_t numInputs = inputArray.getCount ();
@@ -932,8 +941,7 @@ namespace COLLADASaxFWL
                 SourceBase* sourceBase = getSourceById ( sourceId );
                 if ( sourceBase == 0 ) 
                 {
-                    handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "SourceBase of tex coords with semantic TEXCOORD not valid!" );
-                    return;
+                    return handleFWLError ( SaxFWLError::ERROR_DATA_NOT_VALID, "SourceBase of tex coords with semantic TEXCOORD not valid!" );
                 }
 
                 // only stride 1, 2, 3 or 4 makes sense for uv coords
@@ -953,6 +961,7 @@ namespace COLLADASaxFWL
                 mTexCoordList.push_back ( texCoord );
             }
         }
+		return false;
     }
 
 
@@ -1385,13 +1394,15 @@ namespace COLLADASaxFWL
 		case TRIANGLES:
 			{
 				loadSourceElements(mMeshPrimitiveInputs);
-				initializeOffsets();
+				if (initializeOffsets())
+					return false; // abort
 			}
 			break;
         case LINES:
             {
                 loadSourceElements(mMeshPrimitiveInputs);
-                initializeOffsets();
+				if (initializeOffsets())
+					return false; // abort
                 mCurrentMeshPrimitive = new COLLADAFW::Lines(createUniqueId(COLLADAFW::Lines::ID()));
                 if ( mCurrentCOLLADAPrimitiveCount > 0)
                 {
@@ -1411,7 +1422,8 @@ namespace COLLADASaxFWL
 				if ( mPOrPhElementCountOfCurrentPrimitive == 0)
 				{
 					loadSourceElements(mMeshPrimitiveInputs);
-					initializeOffsets();
+					if (initializeOffsets())
+						return false; // abort
 				}
 				int currentTrifanVertexCount = (int)mCurrentVertexCount - (int)mCurrentLastPrimitiveVertexCount;
 				if ( currentTrifanVertexCount > 0 )
@@ -1450,7 +1462,8 @@ namespace COLLADASaxFWL
 				if ( mPOrPhElementCountOfCurrentPrimitive == 0)
 				{
 					loadSourceElements(mMeshPrimitiveInputs);
-					initializeOffsets();
+					if (initializeOffsets())
+						return false; // abort
 				}
 			}
 			break;

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
@@ -926,7 +926,6 @@ namespace COLLADASaxFWL
     //------------------------------
     bool MeshLoader::initializeTexCoordsOffset ()
     {
-		bool has_errors = false;
         // Check for using tex coordinates 
         const InputSharedArray& inputArray = mMeshPrimitiveInputs.getInputArray ();
         size_t numInputs = inputArray.getCount ();


### PR DESCRIPTION
I found a sort of data error that would create bad behavior (null pointer exceptions) within the openCollada library functions. Actually the Collada file does not follow the Collada specifications in this case, see bugreport here: https://developer.blender.org/T50996

The following patch avoids nullpointer issues, allows to handle this sort of error in a more appropriate way via a callback to an error handler and a graceful abort of the import of the broken data.