### PR TITLE
Fix/colladamax/helix export crash

### DIFF
--- a/COLLADAMax/scripts/COLLADAMax.vcxproj
+++ b/COLLADAMax/scripts/COLLADAMax.vcxproj
@@ -983,7 +983,7 @@
     <OutDir>..\bin\win\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>..\obj\win\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
+    <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Max2013_static|Win32'">
     <OutDir>..\bin\win\$(Platform)\$(Configuration)\</OutDir>

--- a/COLLADAMax/scripts/COLLADAMax.vcxproj
+++ b/COLLADAMax/scripts/COLLADAMax.vcxproj
@@ -983,7 +983,7 @@
     <OutDir>..\bin\win\$(Platform)\$(Configuration)\</OutDir>
     <IntDir>..\obj\win\$(Platform)\$(Configuration)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Max2013_static|Win32'">
     <OutDir>..\bin\win\$(Platform)\$(Configuration)\</OutDir>
@@ -2219,7 +2219,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "%25ADSK_3DSMAX_x64_2016%25\plugins\ColladaMaxNew.dle"</Command>
+      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "$(ADSK_3DSMAX_x64_2017)plugins\ColladaMaxNew.dle"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug_Max2013_static|Win32'">
@@ -2655,7 +2655,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "%25MAX_PATH2016_X64%25\plugins\ColladaMaxNew.dle"</Command>
+      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "$(ADSK_3DSMAX_x64_2017)plugins\ColladaMaxNew.dle"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Max2013|Win32'">
@@ -3166,7 +3166,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "%25ADSK_3DSMAX_x64_2012%25\plugins\ColladaMaxNew.dle"</Command>
+      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "$(ADSK_3DSMAX_x64_2017)plugins\ColladaMaxNew.dle"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release_Max2013_static|Win32'">
@@ -3636,7 +3636,7 @@
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "%25MAX_PATH2016_X64%25\plugins\ColladaMaxNew.dle"</Command>
+      <Command>copy "$(OutDir)COLLADAMaxNew.dle" "$(ADSK_3DSMAX_x64_2017)plugins\ColladaMaxNew.dle"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/COLLADAMax/src/COLLADAMaxExportNode.cpp
+++ b/COLLADAMax/src/COLLADAMaxExportNode.cpp
@@ -164,6 +164,7 @@ namespace COLLADAMax
 			if (classId == Class_ID(HELIX_CLASS_ID, 0))
 			{
 				// TODO export helix as <geometry>/<mesh>/<linestrips>
+				GetCOREInterface()->Log()->LogEntry(SYSLOG_WARN, FALSE, _M("OpenCOLLADA export"), _M("Helix node type is not supported. Node not exported."));
 				return ExportNode::UNKNOWN;
 			}
 			return SPLINE;

--- a/COLLADAMax/src/COLLADAMaxExportNode.cpp
+++ b/COLLADAMax/src/COLLADAMaxExportNode.cpp
@@ -27,6 +27,7 @@
 #include <modstack.h>
 #include <cs/bipexp.h>
 #include <surf_api.h>
+#include <plugapi.h>
 
 namespace COLLADAMax
 {
@@ -160,10 +161,12 @@ namespace COLLADAMax
 				// We do not support NURBS here and use mesh instead
 				//return NURBS_CURVE;
 			}
-			else
+			if (classId == Class_ID(HELIX_CLASS_ID, 0))
 			{
-				return SPLINE;
+				// TODO export helix as <geometry>/<mesh>/<linestrips>
+				return ExportNode::UNKNOWN;
 			}
+			return SPLINE;
 		case HELPER_CLASS_ID: 
 			return (classId.PartA() == BONE_CLASS_ID) ? BONE : HELPER;
 		


### PR DESCRIPTION
Don't crash when exporting a scene containing an helix.