### PR TITLE
fix for clang

### DIFF
--- a/COLLADABaseUtils/include/COLLADABUhash_map.h
+++ b/COLLADABaseUtils/include/COLLADABUhash_map.h
@@ -70,7 +70,7 @@
     #define COLLADABU_HASH_NAMESPACE_CLOSE
     #define COLLADABU_HASH_FUN hash
 #else   // Linux or Mac or FreeBSD with GCC
-    #if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)
+    #if (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)) && !defined(__clang__)
         #include <ext/hash_map>
         #include <ext/hash_set>
     #if !(defined(__APPLE__) && defined(__MACH__))


### PR DESCRIPTION
This patch was reported to be good for building OpenCollada on linux with clang.
Thanks to Jens Verwiebe from the Blender developer team.