### PR TITLE
Expose String ID Attribute -> UniqueId Map

### DIFF
--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLoader.h
@@ -378,6 +378,11 @@ namespace COLLADASaxFWL
         @return The elements COLLADAFW::UniqueId */
         COLLADAFW::UniqueId getUniqueId(COLLADAFW::ClassId classId);
         
+		/** Returns the map of COLLADAFW::URIs to COLLADAFW::UniqueIds. This can be used, for example,
+		to figure out the original ID or target attribute of an input element from the relevant UniqueId.
+		@preturn The URIUniqueIdMap for this loader. */
+		const URIUniqueIdMap& getUniqueIdMap(void) const;
+
 	private:
 		friend class IFilePartLoader;
 		friend class FileLoader;

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLoader.cpp
@@ -120,6 +120,11 @@ namespace COLLADASaxFWL
 	}
 
 	//---------------------------------
+	const COLLADASaxFWL::Loader::URIUniqueIdMap& Loader::getUniqueIdMap(void) const
+	{
+		return mURIUniqueIdMap;
+	}
+	//---------------------------------
 	COLLADAFW::FileId Loader::getFileId( const COLLADABU::URI& uri )
 	{
 		// check if the uri is relative


### PR DESCRIPTION
Many applications that read and then re-write DAE files need access to the mapping between the original ID attribute tag values and the internal COLLADAFW::UniqueId values to create output COLLADA files with the correct IDs. Currently, this member is not exposed anywhere. This PR provides a public const reference to this internal member.