### PR TITLE
Add signed char keyword

### DIFF
--- a/COLLADABaseUtils/src/COLLADABUURI.cpp
+++ b/COLLADABaseUtils/src/COLLADABUURI.cpp
@@ -32,7 +32,7 @@ namespace COLLADABU
 
 
 
-	const char HEX2DEC[256] = 
+	const signed char HEX2DEC[256] = 
 	{
 		/*       0  1  2  3   4  5  6  7   8  9  A  B   C  D  E  F */
 		/* 0 */ -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
@@ -107,9 +107,9 @@ namespace COLLADABU
 		{
 			if (*pSrc == '%')
 			{
-				char dec1, dec2;
-				if (    (char)(-1) != (dec1 = HEX2DEC[*(pSrc + 1)])
-				     && (char)(-1) != (dec2 = HEX2DEC[*(pSrc + 2)]))
+				signed char dec1, dec2;
+				if (    (signed char)(-1) != (dec1 = HEX2DEC[*(pSrc + 1)])
+				     && (signed char)(-1) != (dec2 = HEX2DEC[*(pSrc + 2)]))
 				{
 					*pEnd++ = (dec1 << 4) + dec2;
 					pSrc += 3;


### PR DESCRIPTION
On PowerPC and PowerPC64 systems, 'char' is unsigned by default.
Can be reproduced by using the -funsigned-char flag for gcc.
Adding the signed keyword adds compatibility on these systems.

Signed-off by: Jonathan Scruggs <j.scruggs@gmail.com>

Note: I think git changed the formatting of the second part of the patch as I didn't touch that code. I don't know how to tell git to leave that how it was originally, so you can ignore the second hunk of the patch if you want. Or, if you let me know how to tell git to leave it alone, then I can repush the patch.