### PR TITLE
Load images declared in profile_COMMON

### DIFF
--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryEffectsLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryEffectsLoader.h
@@ -3,7 +3,7 @@
 
     This file is part of COLLADASaxFrameworkLoader.
 
-    Licensed under the MIT Open Source License, 
+    Licensed under the MIT Open Source License,
     for details please see LICENSE file or the website
     http://www.opensource.org/licenses/mit-license.php
 */
@@ -216,12 +216,13 @@ namespace COLLADASaxFWL
         /** Store the sid of the new param.*/
         virtual bool begin__newparam____cg_newparam( const newparam____cg_newparam__AttributeData& attributeData );
 
-		/** Set the current profile to PROFILE_COMMON. Create and append common effect to current 
+		/** Set the current profile to PROFILE_COMMON. Create and append common effect to current
 		effect.*/
 		virtual bool begin__profile_COMMON( const profile_COMMON__AttributeData& attributeData );
 
 		/** Set the current profile to unknown.*/
 		virtual bool end__profile_COMMON();
+
 
 		/** Store the sid of the new param.*/
 		virtual bool begin__newparam____common_newparam_type( const newparam____common_newparam_type__AttributeData& attributeData );
@@ -255,7 +256,7 @@ namespace COLLADASaxFWL
         virtual bool begin__minfilter(){return true;}
         virtual bool end__minfilter(){return true;}
         virtual bool data__minfilter( const ENUM__fx_sampler_filter_common value );
-        
+
 		/** We don't need to do anything here.*/
 		virtual bool begin__source____NCName(){return true;}
 
@@ -286,7 +287,7 @@ namespace COLLADASaxFWL
 		/** Resolve all the samplers and copy them to the current effect.*/
 		virtual bool begin__profile_COMMON__technique( const profile_COMMON__technique__AttributeData& attributeData );
 
-        /** Iterate over the list of used samplers in the current effect profile and push them 
+        /** Iterate over the list of used samplers in the current effect profile and push them
             in the sampler array. */
         bool fillSamplerArray();
 
@@ -374,7 +375,7 @@ namespace COLLADASaxFWL
 
 	private:
 		/** Set the shader type of the current profile.*/
-		bool setCommonEffectShaderType( COLLADAFW::EffectCommon::ShaderType shaderType); 
+		bool setCommonEffectShaderType( COLLADAFW::EffectCommon::ShaderType shaderType);
 
 		/** Stores color data into the correct color object.*/
 		bool handleColorData( const float* value, size_t length );
@@ -388,7 +389,7 @@ namespace COLLADASaxFWL
 		bool handleExtraEffectTextures( const COLLADAFW::PointerArray<COLLADAFW::TextureAttributes>& effectTextures );
 
         /**
-         * Luminance is the function, based on the ISO/CIE color standards (see ITU-R 
+         * Luminance is the function, based on the ISO/CIE color standards (see ITU-R
          * Recommendation BT.709-4), that averages the color channels into one value.
          */
         double calculateLuminance ( const COLLADAFW::Color& color );

--- a/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryEffectsLoader.h
+++ b/COLLADASaxFrameworkLoader/include/COLLADASaxFWLLibraryEffectsLoader.h
@@ -11,9 +11,7 @@
 #ifndef __COLLADASAXFWL_LIBRARYEFFECTSSLOADER_H__
 #define __COLLADASAXFWL_LIBRARYEFFECTSSLOADER_H__
 
-#include "COLLADASaxFWLPrerequisites.h"
-#include "COLLADASaxFWLFilePartLoader.h"
-#include "COLLADASaxFWLXmlTypes.h"
+#include "COLLADASaxFWLLibraryImagesLoader.h"
 
 #include "COLLADAFWEffectCommon.h"
 #include "COLLADAFWTypes.h"
@@ -32,7 +30,7 @@ namespace COLLADASaxFWL
 {
 
     /** TODO Documentation */
-	class LibraryEffectsLoader : public FilePartLoader
+	class LibraryEffectsLoader : public LibraryImagesLoader
 	{
     public:
 		enum ShaderParameterTypes
@@ -224,7 +222,6 @@ namespace COLLADASaxFWL
 
 		/** Set the current profile to unknown.*/
 		virtual bool end__profile_COMMON();
-
 
 		/** Store the sid of the new param.*/
 		virtual bool begin__newparam____common_newparam_type( const newparam____common_newparam_type__AttributeData& attributeData );

--- a/COLLADASaxFrameworkLoader/include/generated14/COLLADASaxFWLLibraryEffectsLoader14.h
+++ b/COLLADASaxFrameworkLoader/include/generated14/COLLADASaxFWLLibraryEffectsLoader14.h
@@ -15,7 +15,7 @@
 
 #include "COLLADASaxFWLPrerequisites.h"
 #include "COLLADASaxFWLLibraryEffectsLoader.h"
-#include "COLLADASaxFWLIParserImpl14.h"
+#include "COLLADASaxFWLLibraryImagesLoader14.h"
 
 
 namespace COLLADASaxFWL
@@ -25,14 +25,14 @@ namespace COLLADASaxFWL
 class IFilePartLoader;
 
 
-class LibraryEffectsLoader14 : public IParserImpl14
+class LibraryEffectsLoader14 : public LibraryImagesLoader14
 {
 private:
 LibraryEffectsLoader* mLoader;
 
 public:
 LibraryEffectsLoader14(LibraryEffectsLoader* loader)
- : mLoader(loader)
+ : LibraryImagesLoader14(static_cast<LibraryImagesLoader*>(loader)), mLoader(loader)
 {}
 
 

--- a/COLLADASaxFrameworkLoader/include/generated15/COLLADASaxFWLLibraryEffectsLoader15.h
+++ b/COLLADASaxFrameworkLoader/include/generated15/COLLADASaxFWLLibraryEffectsLoader15.h
@@ -15,7 +15,7 @@
 
 #include "COLLADASaxFWLPrerequisites.h"
 #include "COLLADASaxFWLLibraryEffectsLoader.h"
-#include "COLLADASaxFWLIParserImpl15.h"
+#include "COLLADASaxFWLLibraryImagesLoader15.h"
 
 
 namespace COLLADASaxFWL
@@ -25,14 +25,14 @@ namespace COLLADASaxFWL
 class IFilePartLoader;
 
 
-class LibraryEffectsLoader15 : public IParserImpl15
+class LibraryEffectsLoader15 : public LibraryImagesLoader15
 {
 private:
 LibraryEffectsLoader* mLoader;
 
 public:
 LibraryEffectsLoader15(LibraryEffectsLoader* loader)
- : mLoader(loader)
+ : LibraryImagesLoader15(static_cast<LibraryImagesLoader*>(loader)), mLoader(loader)
 {}
 
 

--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryEffectsLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryEffectsLoader.cpp
@@ -22,7 +22,7 @@ namespace COLLADASaxFWL
 
     //------------------------------
 	LibraryEffectsLoader::LibraryEffectsLoader( IFilePartLoader* callingFilePartLoader )
-		: FilePartLoader(callingFilePartLoader)
+		: LibraryImagesLoader(callingFilePartLoader)
 		, mCurrentEffect(0)
         , mTransparency(1)
 		, mOpaqueMode(UNSPECIFIED_OPAQUE)


### PR DESCRIPTION
Fix for #571.

This is probably the simplest way to solve this issue. The effect loaders subclass from the image loaders so that they reuse all of the image loading machinery without needing to duplicate it in the effect loaders.