### PR TITLE
Use more Linux codepaths on any GNU libc-based system

### DIFF
--- a/COLLADABaseUtils/src/COLLADABUNativeString.cpp
+++ b/COLLADABaseUtils/src/COLLADABUNativeString.cpp
@@ -57,7 +57,7 @@ namespace COLLADABU
 		WideCharToMultiByte( CP_ACP, 0, (LPCWSTR)wideString.c_str(), -1, dest, multibyteLength, 0, 0 );
 		this->assign( dest );
 		delete[] dest;
-#elif defined (COLLADABU_OS_LINUX) || defined (COLLADABU_OS_MAC)
+#elif defined (COLLADABU_OS_LINUX) || defined (COLLADABU_OS_MAC) || defined (__GLIBC__)
 //# error check if this really works on linux
 		size_t maxStringLength = wcstombs( 0, wideString.c_str(), 0 ) + 1; // wideString.length()*MB_CUR_MAX + 1;
 		char* dest = new char[ maxStringLength ];
@@ -80,7 +80,7 @@ namespace COLLADABU
 		WideString returnValue( dest );
 		delete[] dest;
 		return returnValue;
-#elif defined (COLLADABU_OS_LINUX) || defined (COLLADABU_OS_MAC)
+#elif defined (COLLADABU_OS_LINUX) || defined (COLLADABU_OS_MAC) || defined (__GLIBC__)
 //# error check if this really works on linux
 
 		size_t maxStringLength = length() + 1;

--- a/GeneratedSaxParser/include/GeneratedSaxParserPrerequisites.h
+++ b/GeneratedSaxParser/include/GeneratedSaxParserPrerequisites.h
@@ -62,7 +62,7 @@ namespace GeneratedSaxParser
     typedef unsigned int uint32;
     typedef unsigned long long uint64;
 
-#elif defined COLLADABU_OS_LINUX
+#elif defined COLLADABU_OS_LINUX || defined __GLIBC__
     typedef signed char sint8;
     typedef signed short sint16;
     typedef signed int sint32;


### PR DESCRIPTION
These code paths apply / work fine on any system based on GNU libc, so extend the checks to include also `defined(__GLIBC__)`.

I did not add a `COLLADABU_OS_GLIBC` or so because it seemed overkill to me, although I can add it (and use it) if needed/wanted.