### PR TITLE
Animation id should refer to top-level animation, not sampler

### DIFF
--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryAnimationsLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLLibraryAnimationsLoader.cpp
@@ -368,7 +368,7 @@ namespace COLLADASaxFWL
 	//------------------------------
 	bool LibraryAnimationsLoader::begin__sampler( const sampler__AttributeData& attributeData )
 	{
-		mCurrentAnimationCurve = FW_NEW COLLADAFW::AnimationCurve(createUniqueIdFromId(attributeData.id, COLLADAFW::Animation::ID()));
+		mCurrentAnimationCurve = FW_NEW COLLADAFW::AnimationCurve(createUniqueIdFromId(mOriginalId.c_str(), COLLADAFW::Animation::ID()));
 
 		mCurrentAnimationCurve->setName ( mName );
         mCurrentAnimationCurve->setOriginalId ( mOriginalId );


### PR DESCRIPTION
@RemiArnaud, could you take a look at this when you get a chance?

Currently the id of the animation object is created from the sampler, not the animation, so references (from animation clips, for example), are broken.