### PR TITLE
Resolving compilation error on macOS

### DIFF
--- a/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
+++ b/GeneratedSaxParser/src/GeneratedSaxParserUtils.cpp
@@ -10,6 +10,7 @@
 
 #include "GeneratedSaxParserUtils.h"
 #include <math.h>
+#include <cmath>
 #include <memory>
 #include <string.h>
 #include <limits>


### PR DESCRIPTION
As stated in https://github.com/KhronosGroup/OpenCOLLADA/issues/594 a missing import causes a  "no member named 'isnan' in namespace 'std'" compilation error on macOS. This change includes the missing `cmath` library.
