### PR TITLE
Rather use default constructor of std::vector in LibraryAnimations::L…

### DIFF
--- a/COLLADAStreamWriter/src/COLLADASWLibraryAnimations.cpp
+++ b/COLLADAStreamWriter/src/COLLADASWLibraryAnimations.cpp
@@ -62,7 +62,7 @@ namespace COLLADASW
 
     //---------------------------------------------------------------
     LibraryAnimations::LibraryAnimations ( COLLADASW::StreamWriter * streamWriter )
-            : Library ( streamWriter, CSWC::CSW_ELEMENT_LIBRARY_ANIMATIONS ), mOpenAnimations ( NULL )
+            : Library ( streamWriter, CSWC::CSW_ELEMENT_LIBRARY_ANIMATIONS )
     {}
 
     //---------------------------------------------------------------


### PR DESCRIPTION
…ibraryAnimations than `mOpenAnimation(NULL)`

This avoid the following warning:

```
../COLLADAStreamWriter/src/COLLADASWLibraryAnimations.cpp:65:97: warning: implicit conversion of NULL constant to 'std::vector::size_type' (aka 'unsigned long') [-Wnull-conversion]
            : Library ( streamWriter, CSWC::CSW_ELEMENT_LIBRARY_ANIMATIONS ), mOpenAnimations ( NULL )
                                                                              ~~~~~~~~~~~~~~~   ^~~~
                                                                                                0
```