### PR TITLE
Build: update cmake minimum version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 	endif()
 endif()
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
cmake ABI compatibility with cmake <3.5 has been removed in cmake 4. Compatibility with cmake <3.10 is deprecated and soon to be removed. Thus set 3.10 minimum version. This is available in the vast majority of current linux distributions, as well as other platforms.

This project looks somewhat dead, i do not expect a merge. But i might as well post the patch here.
Gentoo already did a similar patch, see https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/opencollada/files/opencollada-1.6.68-cmake4.patch?id=42f1e0614c4d056841fdc162c29a04ff0e910139. They did however not upstream their work.
